### PR TITLE
docs: expand repository readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# working-with-toc
+# Working with TOC
+
+## Table of Contents
+- [Overview](#overview)
+- [Repository Layout](#repository-layout)
+- [Getting Started](#getting-started)
+- [Working with Markdown Tables of Contents](#working-with-markdown-tables-of-contents)
+  - [Manual Updates](#manual-updates)
+  - [Automatic Generation](#automatic-generation)
+  - [Verification Checklist](#verification-checklist)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Overview
+
+This repository is a deliberately minimal playground for practicing how to structure and maintain a Markdown table of contents (TOC). The only tracked file is this `README.md`, making it an ideal space to experiment with formatting, organization, and documentation workflows without distractions from other source files.
+
+## Repository Layout
+
+```
+working-with-toc/
+└── README.md   # Primary documentation and TOC experimentation ground
+```
+
+Because everything happens inside the README, you can focus entirely on documenting processes, capturing conventions, and refining the TOC without needing to manage additional assets.
+
+## Getting Started
+
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd working-with-toc
+   ```
+2. **Create a feature branch** for your documentation updates.
+   ```bash
+   git checkout -b docs/update-readme
+   ```
+3. **Edit `README.md`** to practice reorganizing content, adding new sections, or experimenting with TOC formats.
+4. **Commit and push** your changes when you are satisfied with the structure.
+
+## Working with Markdown Tables of Contents
+
+The TOC at the top of this file illustrates a manually curated set of anchor links pointing to the major sections below. Depending on your workflow, you can update the TOC by hand or rely on automation tools.
+
+### Manual Updates
+
+- Keep the TOC near the top of the document so readers can immediately jump to relevant sections.
+- Ensure each entry matches the exact spelling and capitalization of the corresponding heading, with spaces replaced by hyphens in the anchor link.
+- When adding new headings, update the TOC in the same commit to avoid broken navigation.
+
+### Automatic Generation
+
+If you prefer automation, tools such as [`markdown-toc`](https://github.com/jonschlinkert/markdown-toc), VS Code extensions like *Markdown All in One*, or GitHub Actions can generate and refresh the TOC for you.
+
+1. Install your preferred tool locally.
+2. Run it against `README.md` to rebuild the TOC after you introduce new headings.
+3. Review the diff to confirm that anchors and indentation levels match your expectations.
+
+### Verification Checklist
+
+Before opening a pull request, double-check:
+
+- [ ] Every top-level heading (`##`) is represented in the TOC.
+- [ ] Nested bullet points reflect the heading hierarchy.
+- [ ] Internal links navigate correctly when clicked in the GitHub preview.
+- [ ] Markdown renders cleanly without lint warnings.
+
+## Contributing
+
+1. Fork the repository or work on a dedicated branch.
+2. Make focused documentation changes (for example, adding a new section or improving the TOC).
+3. Verify the TOC and Markdown formatting.
+4. Submit a pull request describing your updates and the documentation improvements made.
+
+## License
+
+No explicit license has been provided yet. If you plan to share or reuse the content, please coordinate with the repository maintainer to clarify licensing expectations.


### PR DESCRIPTION
## Summary
- add a table of contents to README.md for quick navigation
- document the repository purpose, layout, and usage workflow
- provide guidance for maintaining Markdown tables of contents and contributing updates

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68de517103848333b2d46f86471b54aa