### PR TITLE
Add sticky TOC plugin with SEO integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,75 @@
 # Working with TOC
 
-## Table of Contents
-- [Overview](#overview)
-- [Repository Layout](#repository-layout)
-- [Getting Started](#getting-started)
-- [Working with Markdown Tables of Contents](#working-with-markdown-tables-of-contents)
-  - [Manual Updates](#manual-updates)
-  - [Automatic Generation](#automatic-generation)
-  - [Verification Checklist](#verification-checklist)
-- [Contributing](#contributing)
-- [License](#license)
+## Sommario
+- [Panoramica](#panoramica)
+- [Caratteristiche principali](#caratteristiche-principali)
+- [Struttura del plugin](#struttura-del-plugin)
+- [Impostazioni di backend](#impostazioni-di-backend)
+- [Funzionalità frontend](#funzionalità-frontend)
+- [Compatibilità SEO](#compatibilità-seo)
+- [Log e debug](#log-e-debug)
+- [Guida rapida](#guida-rapida)
 
-## Overview
+## Panoramica
 
-This repository is a deliberately minimal playground for practicing how to structure and maintain a Markdown table of contents (TOC). The only tracked file is this `README.md`, making it an ideal space to experiment with formatting, organization, and documentation workflows without distractions from other source files.
+**Working with TOC** è un plugin WordPress pensato per creare automaticamente un indice dei contenuti elegante e mobile-friendly per articoli, pagine e prodotti. Il progetto dimostra una suddivisione del codice secondo le convenzioni WordPress (cartelle `includes/`, `admin/`, `frontend/`, `assets/`) e include strumenti per generare dati strutturati compatibili con Rank Math e Yoast SEO.
 
-## Repository Layout
+## Caratteristiche principali
+
+- Accordion TOC fisso nella parte inferiore dello schermo con design moderno e supporto touch.
+- Generazione automatica degli anchor ID sui titoli `<h2>-<h6>` e sincronizzazione con gli URL della TOC.
+- Pannello di amministrazione personalizzato con interruttori per attivare TOC e dati strutturati per articoli, pagine e prodotti WooCommerce.
+- Output JSON-LD dedicato al tipo `TableOfContents` per articoli, pagine e prodotti, integrato nel grafo schema di Yoast SEO e riconosciuto da Rank Math.
+- Logging condizionato sul flag `WP_DEBUG` per agevolare il debug senza inquinare l'ambiente di produzione.
+
+## Struttura del plugin
 
 ```
 working-with-toc/
-└── README.md   # Primary documentation and TOC experimentation ground
+├── working-with-toc.php
+├── assets/
+│   ├── css/
+│   │   ├── admin.css
+│   │   └── frontend.css
+│   └── js/
+│       ├── admin.js
+│       └── frontend.js
+├── includes/
+│   ├── admin/
+│   │   └── class-admin-page.php
+│   ├── frontend/
+│   │   └── class-frontend.php
+│   ├── structured-data/
+│   │   └── class-structured-data-manager.php
+│   ├── class-autoloader.php
+│   ├── class-heading-parser.php
+│   ├── class-logger.php
+│   ├── class-plugin.php
+│   └── class-settings.php
+└── README.md
 ```
 
-Because everything happens inside the README, you can focus entirely on documenting processes, capturing conventions, and refining the TOC without needing to manage additional assets.
+## Impostazioni di backend
 
-## Getting Started
+Nel menu di amministrazione viene aggiunta una pagina “Working with TOC” con tre card dedicate ai diversi tipi di contenuto. Ogni card include uno switch moderno per attivare o disattivare la TOC e i relativi dati strutturati. Il layout utilizza gradienti, ombre morbide e micro-animazioni per un aspetto premium.
 
-1. **Clone the repository**
-   ```bash
-   git clone <repository-url>
-   cd working-with-toc
-   ```
-2. **Create a feature branch** for your documentation updates.
-   ```bash
-   git checkout -b docs/update-readme
-   ```
-3. **Edit `README.md`** to practice reorganizing content, adding new sections, or experimenting with TOC formats.
-4. **Commit and push** your changes when you are satisfied with the structure.
+## Funzionalità frontend
 
-## Working with Markdown Tables of Contents
+La TOC viene generata e mostrata in un accordion fissato al bordo inferiore della finestra. Gli utenti possono aprirla o chiuderla rapidamente; quando è aperta, il contenuto scorre all'interno di un pannello a scomparsa con evidenziazione dinamica della sezione in lettura grazie a `IntersectionObserver`.
 
-The TOC at the top of this file illustrates a manually curated set of anchor links pointing to the major sections below. Depending on your workflow, you can update the TOC by hand or rely on automation tools.
+## Compatibilità SEO
 
-### Manual Updates
+- **Rank Math**: il plugin si registra tra i TOC supportati, evitando l’avviso “Nessun plugin TOC installato”.
+- **Yoast SEO**: i dati strutturati vengono aggiunti al grafo esistente tramite il filtro `wpseo_schema_graph` senza conflitti.
+- **Schema.org**: viene generato un nodo `TableOfContents` con riferimenti diretti alle intestazioni del contenuto, con URL coerenti con l’anchor ID generato nel markup.
 
-- Keep the TOC near the top of the document so readers can immediately jump to relevant sections.
-- Ensure each entry matches the exact spelling and capitalization of the corresponding heading, with spaces replaced by hyphens in the anchor link.
-- When adding new headings, update the TOC in the same commit to avoid broken navigation.
+## Log e debug
 
-### Automatic Generation
+Le operazioni principali (inizializzazione, salvataggio impostazioni, rendering schema) vengono tracciate attraverso `error_log` quando `WP_DEBUG` è impostato su `true`, fornendo informazioni utili senza influenzare l’ambiente live.
 
-If you prefer automation, tools such as [`markdown-toc`](https://github.com/jonschlinkert/markdown-toc), VS Code extensions like *Markdown All in One*, or GitHub Actions can generate and refresh the TOC for you.
+## Guida rapida
 
-1. Install your preferred tool locally.
-2. Run it against `README.md` to rebuild the TOC after you introduce new headings.
-3. Review the diff to confirm that anchors and indentation levels match your expectations.
-
-### Verification Checklist
-
-Before opening a pull request, double-check:
-
-- [ ] Every top-level heading (`##`) is represented in the TOC.
-- [ ] Nested bullet points reflect the heading hierarchy.
-- [ ] Internal links navigate correctly when clicked in the GitHub preview.
-- [ ] Markdown renders cleanly without lint warnings.
-
-## Contributing
-
-1. Fork the repository or work on a dedicated branch.
-2. Make focused documentation changes (for example, adding a new section or improving the TOC).
-3. Verify the TOC and Markdown formatting.
-4. Submit a pull request describing your updates and the documentation improvements made.
-
-## License
-
-No explicit license has been provided yet. If you plan to share or reuse the content, please coordinate with the repository maintainer to clarify licensing expectations.
+1. Copia la cartella del plugin all’interno di `wp-content/plugins/` e attivalo da WordPress.
+2. Visita **Impostazioni → Working with TOC** per scegliere dove abilitare la TOC e i dati strutturati.
+3. Modifica o crea un articolo/prodotto: il plugin aggiungerà automaticamente l’indice dei contenuti in un accordion sticky in fondo alla pagina.
+4. Verifica con Rank Math o Yoast SEO che l’analisi riconosca la TOC e i dati strutturati.

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,165 @@
+:root {
+    --wwt-primary: #5d5fef;
+    --wwt-secondary: #7f53ac;
+    --wwt-bg: linear-gradient(135deg, rgba(95,93,239,0.85), rgba(127,83,172,0.85));
+    --wwt-card-bg: #ffffff;
+    --wwt-text: #1f2933;
+}
+
+.wwt-toc-admin {
+    position: relative;
+    padding: 2rem 2.5rem 3rem;
+    background: var(--wwt-bg), url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400"><defs><linearGradient id="g" x1="0%" x2="100%" y1="0%" y2="100%"><stop offset="0%" stop-color="%235d5fef" stop-opacity="0.3"/><stop offset="100%" stop-color="%237f53ac" stop-opacity="0.3"/></linearGradient></defs><rect width="400" height="400" fill="url(%23g)"/><circle cx="50" cy="50" r="30" fill="%235d5fef" opacity="0.15"/><circle cx="350" cy="120" r="50" fill="%237f53ac" opacity="0.15"/></svg>') no-repeat center/cover;
+    border-radius: 18px;
+    color: #ffffff;
+    overflow: hidden;
+    box-shadow: 0 25px 60px rgba(17, 12, 46, 0.25);
+}
+
+.wwt-toc-admin h1 {
+    font-size: 2.4rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.wwt-toc-admin .wwt-toc-subtitle {
+    font-size: 1.05rem;
+    max-width: 48rem;
+    margin-bottom: 2rem;
+}
+
+.wwt-toc-form {
+    background: rgba(255, 255, 255, 0.88);
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+    backdrop-filter: blur(8px);
+    color: var(--wwt-text);
+}
+
+.wwt-toc-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.wwt-toc-card {
+    background: var(--wwt-card-bg);
+    border-radius: 14px;
+    padding: 1.5rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 15px 40px rgba(15, 23, 42, 0.1);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.wwt-toc-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(95,93,239,0.1), rgba(127,83,172,0.15));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+}
+
+.wwt-toc-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+}
+
+.wwt-toc-card:hover::before {
+    opacity: 1;
+}
+
+.wwt-toc-card h2 {
+    font-size: 1.25rem;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+.wwt-toc-card p {
+    margin-bottom: 1.25rem;
+    color: #52616b;
+}
+
+.wwt-switch {
+    position: relative;
+    display: inline-block;
+    width: 54px;
+    height: 28px;
+}
+
+.wwt-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.wwt-slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: #d1d5db;
+    border-radius: 34px;
+    transition: background-color 0.2s ease;
+}
+
+.wwt-slider::before {
+    position: absolute;
+    content: '';
+    height: 22px;
+    width: 22px;
+    left: 3px;
+    bottom: 3px;
+    background-color: #ffffff;
+    border-radius: 50%;
+    transition: transform 0.2s ease;
+    box-shadow: 0 10px 20px rgba(93, 95, 239, 0.25);
+}
+
+.wwt-switch input:checked + .wwt-slider {
+    background: linear-gradient(135deg, #5d5fef, #7f53ac);
+}
+
+.wwt-switch input:checked + .wwt-slider::before {
+    transform: translateX(26px);
+}
+
+.wwt-toc-submit {
+    text-align: right;
+}
+
+.wwt-toc-submit .button-primary {
+    background: linear-gradient(135deg, #5d5fef, #7f53ac);
+    border: none;
+    box-shadow: 0 15px 35px rgba(95, 93, 239, 0.35);
+    padding: 0.6rem 1.6rem;
+    font-size: 1rem;
+    border-radius: 999px;
+}
+
+.wwt-toc-submit .button-primary:hover {
+    box-shadow: 0 20px 45px rgba(95, 93, 239, 0.45);
+}
+
+.wwt-toc-footer {
+    margin-top: 1.5rem;
+    text-align: center;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+@media (max-width: 782px) {
+    .wwt-toc-admin {
+        padding: 1.5rem;
+    }
+
+    .wwt-toc-form {
+        padding: 1.5rem;
+    }
+
+    .wwt-toc-submit {
+        text-align: center;
+    }
+}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,146 @@
+.wwt-toc-container {
+    position: fixed;
+    left: 1.5rem;
+    right: 1.5rem;
+    bottom: 1.5rem;
+    z-index: 9999;
+    max-width: 420px;
+    margin: 0 auto;
+    background: rgba(24, 31, 55, 0.92);
+    color: #ffffff;
+    border-radius: 18px;
+    box-shadow: 0 25px 55px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(10px);
+    overflow: hidden;
+}
+
+@media (min-width: 960px) {
+    .wwt-toc-container {
+        left: auto;
+        right: 2rem;
+        margin: 0;
+    }
+}
+
+.wwt-toc-toggle {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: inherit;
+    padding: 0.95rem 1.2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.wwt-toc-icon {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    position: relative;
+}
+
+.wwt-toc-icon::before,
+.wwt-toc-icon::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 16px;
+    height: 2px;
+    background: currentColor;
+    transform-origin: center;
+    transition: transform 0.2s ease;
+}
+
+.wwt-toc-icon::before {
+    transform: translate(-50%, -50%);
+}
+
+.wwt-toc-icon::after {
+    transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.wwt-toc-container[data-expanded="true"] .wwt-toc-icon::after {
+    transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.wwt-toc-container[data-expanded="true"] .wwt-toc-icon::before {
+    transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.wwt-toc-content {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 0 1.2rem 1.2rem;
+    background: rgba(17, 24, 39, 0.92);
+}
+
+.wwt-toc-nav {
+    font-size: 0.95rem;
+}
+
+.wwt-toc-list {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+.wwt-toc-list li {
+    margin: 0.35rem 0;
+    line-height: 1.4;
+}
+
+.wwt-level-0 {
+    padding-left: 0;
+}
+
+.wwt-toc-list a {
+    color: rgba(255, 255, 255, 0.9);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.wwt-toc-list a:hover,
+.wwt-toc-list a:focus {
+    color: #63b3ff;
+}
+
+.wwt-toc-list a.is-active {
+    color: #63b3ff;
+    font-weight: 600;
+}
+
+.wwt-level-1 {
+    padding-left: 0.75rem;
+}
+
+.wwt-level-2 {
+    padding-left: 1.5rem;
+}
+
+.wwt-level-3 {
+    padding-left: 2.25rem;
+}
+
+.wwt-level-4,
+.wwt-level-5,
+.wwt-level-6 {
+    padding-left: 3rem;
+}
+
+@media (max-width: 600px) {
+    .wwt-toc-container {
+        left: 1rem;
+        right: 1rem;
+        bottom: 1rem;
+        border-radius: 16px;
+    }
+
+    .wwt-toc-content {
+        max-height: 50vh;
+    }
+}

--- a/assets/css/index.php
+++ b/assets/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,19 @@
+(function ($) {
+    'use strict';
+
+    $(function () {
+        const cards = $('.wwt-toc-card');
+        cards.on('mouseenter', function () {
+            $(this).addClass('wwt-hover');
+        }).on('mouseleave', function () {
+            $(this).removeClass('wwt-hover');
+        });
+
+        const labels = window.wwtTocAdmin || { on: 'attivato', off: 'disattivato' };
+        $('.wwt-switch input').on('change', function () {
+            const label = $(this).closest('.wwt-toc-card').find('h2').text();
+            const state = $(this).is(':checked') ? labels.on : labels.off;
+            wp.a11y.speak(label + ' ' + state);
+        });
+    });
+})(jQuery);

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,88 @@
+(function () {
+    'use strict';
+
+    const cssEscape = (value) => {
+        if (window.CSS && typeof window.CSS.escape === 'function') {
+            return window.CSS.escape(value);
+        }
+        return value.replace(/([\s#:?&.,])/g, '\$1');
+    };
+
+    const containers = document.querySelectorAll('[data-wwt-toc]');
+    if (!containers.length) {
+        return;
+    }
+
+    const togglePanel = (container, expanded) => {
+        const button = container.querySelector('.wwt-toc-toggle');
+        const panel = container.querySelector('.wwt-toc-content');
+
+        container.dataset.expanded = String(expanded);
+        button.setAttribute('aria-expanded', String(expanded));
+        if (expanded) {
+            panel.removeAttribute('hidden');
+        } else {
+            panel.setAttribute('hidden', '');
+        }
+    };
+
+    containers.forEach((container) => {
+        const button = container.querySelector('.wwt-toc-toggle');
+        const panel = container.querySelector('.wwt-toc-content');
+        const links = panel ? Array.from(panel.querySelectorAll('a[href^="#"]')) : [];
+
+        if (!button || !panel) {
+            return;
+        }
+
+        button.addEventListener('click', () => {
+            const expanded = container.dataset.expanded === 'true';
+            togglePanel(container, !expanded);
+        });
+
+        button.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                togglePanel(container, false);
+            }
+        });
+
+        if (links.length) {
+            links.forEach((link) => {
+                link.addEventListener('click', () => togglePanel(container, false));
+            });
+        }
+    });
+
+    const highlightActiveHeading = () => {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach((entry) => {
+                const id = entry.target.getAttribute('id');
+                if (!id) {
+                    return;
+                }
+
+                const link = document.querySelector('.wwt-toc-list a[href="#' + cssEscape(id) + '"]');
+                if (!link) {
+                    return;
+                }
+
+                if (entry.isIntersecting) {
+                    document.querySelectorAll('.wwt-toc-list a.is-active').forEach((active) => {
+                        active.classList.remove('is-active');
+                    });
+                    link.classList.add('is-active');
+                }
+            });
+        }, {
+            rootMargin: '-50% 0px -40% 0px',
+            threshold: 0.1,
+        });
+
+        const targets = document.querySelectorAll('h2[id], h3[id], h4[id], h5[id], h6[id]');
+        targets.forEach((target) => observer.observe(target));
+    };
+
+    if ('IntersectionObserver' in window) {
+        window.addEventListener('load', highlightActiveHeading);
+    }
+})();

--- a/assets/js/index.php
+++ b/assets/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Admin settings page.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+use Working_With_TOC\Logger;
+use Working_With_TOC\Settings;
+
+/**
+ * Render and manage plugin admin page.
+ */
+class Admin_Page {
+
+    /**
+     * Settings object.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param Settings $settings Settings manager.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Register menu item.
+     */
+    public function register_menu(): void {
+        add_menu_page(
+            __( 'Working with TOC', 'working-with-toc' ),
+            __( 'Working with TOC', 'working-with-toc' ),
+            'manage_options',
+            'working-with-toc',
+            array( $this, 'render_page' ),
+            'dashicons-list-view'
+        );
+    }
+
+    /**
+     * Enqueue admin assets.
+     */
+    public function enqueue_assets( string $hook ): void {
+        if ( 'toplevel_page_working-with-toc' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'wwt-toc-admin',
+            WWT_TOC_PLUGIN_URL . 'assets/css/admin.css',
+            array(),
+            WWT_TOC_VERSION
+        );
+
+        wp_enqueue_script(
+            'wwt-toc-admin',
+            WWT_TOC_PLUGIN_URL . 'assets/js/admin.js',
+            array( 'jquery', 'wp-a11y' ),
+            WWT_TOC_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'wwt-toc-admin',
+            'wwtTocAdmin',
+            array(
+                'on'  => __( 'attivato', 'working-with-toc' ),
+                'off' => __( 'disattivato', 'working-with-toc' ),
+            )
+        );
+    }
+
+    /**
+     * Render settings page markup.
+     */
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $settings = $this->settings->get_settings();
+        Logger::log( 'Rendering settings page.' );
+        ?>
+        <div class="wrap wwt-toc-admin">
+            <h1><?php esc_html_e( 'Working with TOC', 'working-with-toc' ); ?></h1>
+            <p class="wwt-toc-subtitle"><?php esc_html_e( 'Gestisci i dati strutturati per articoli, prodotti e pagine.', 'working-with-toc' ); ?></p>
+
+            <form action="options.php" method="post" class="wwt-toc-form">
+                <?php
+                settings_fields( 'wwt_toc_settings_group' );
+                ?>
+                <div class="wwt-toc-card-grid">
+                    <div class="wwt-toc-card">
+                        <h2><?php esc_html_e( 'Articoli', 'working-with-toc' ); ?></h2>
+                        <p><?php esc_html_e( 'Abilita la TOC e i dati strutturati per i post standard.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_posts]" value="1" <?php checked( $settings['enable_posts'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                    <div class="wwt-toc-card">
+                        <h2><?php esc_html_e( 'Pagine', 'working-with-toc' ); ?></h2>
+                        <p><?php esc_html_e( 'Attiva la TOC per le pagine statiche del sito.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_pages]" value="1" <?php checked( $settings['enable_pages'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                    <div class="wwt-toc-card">
+                        <h2><?php esc_html_e( 'Prodotti', 'working-with-toc' ); ?></h2>
+                        <p><?php esc_html_e( 'Integrazione con WooCommerce per schede prodotto complete.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_products]" value="1" <?php checked( $settings['enable_products'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="wwt-toc-submit">
+                    <?php submit_button( __( 'Salva impostazioni', 'working-with-toc' ) ); ?>
+                </div>
+            </form>
+            <footer class="wwt-toc-footer">
+                <p><?php esc_html_e( 'Compatibile con Rank Math e Yoast SEO. Attiva la modalità debug di WordPress per registrare gli eventi del plugin.', 'working-with-toc' ); ?></p>
+            </footer>
+        </div>
+        <?php
+    }
+}

--- a/includes/admin/index.php
+++ b/includes/admin/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PSR-4 like autoloader for plugin classes.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Simple autoloader.
+ */
+class Autoloader {
+
+    /**
+     * Base namespace for the plugin.
+     *
+     * @var string
+     */
+    protected static $namespace = __NAMESPACE__ . '\\';
+
+    /**
+     * Register autoloader with SPL.
+     */
+    public static function register(): void {
+        spl_autoload_register( array( __CLASS__, 'autoload' ) );
+    }
+
+    /**
+     * Handle class autoloading.
+     *
+     * @param string $class Class name.
+     */
+    protected static function autoload( string $class ): void {
+        if ( 0 !== strpos( $class, self::$namespace ) ) {
+            return;
+        }
+
+        $relative = str_replace( self::$namespace, '', $class );
+        $relative = str_replace( '\\', '/', $relative );
+        $relative = strtolower( $relative );
+        $relative = str_replace( '_', '-', $relative );
+
+        $parts    = explode( '/', $relative );
+        $filename = array_pop( $parts );
+        $base_dir = WWT_TOC_PLUGIN_DIR . 'includes/';
+
+        if ( ! empty( $parts ) ) {
+            $base_dir .= implode( '/', $parts ) . '/';
+        }
+
+        $candidates = array(
+            $base_dir . 'class-' . $filename . '.php',
+            $base_dir . $filename . '.php',
+        );
+
+        foreach ( $candidates as $file ) {
+            if ( file_exists( $file ) ) {
+                require_once $file;
+                return;
+            }
+        }
+    }
+}

--- a/includes/class-heading-parser.php
+++ b/includes/class-heading-parser.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Heading parser utility.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+
+/**
+ * Parse headings and ensure IDs.
+ */
+class Heading_Parser {
+
+    /**
+     * Parse content and return headings plus updated content.
+     *
+     * @param string $content HTML content.
+     *
+     * @return array{headings:array<int,array{title:string,id:string,level:int}>,content:string}
+     */
+    public static function parse( string $content ): array {
+        $dom       = new DOMDocument();
+        $previous = libxml_use_internal_errors( true );
+        $dom->loadHTML( '<?xml encoding="utf-8"?>' . $content );
+        libxml_clear_errors();
+        libxml_use_internal_errors( $previous );
+
+        $xpath    = new DOMXPath( $dom );
+        $nodes    = $xpath->query( '//h2 | //h3 | //h4 | //h5 | //h6' );
+        $headings = array();
+        $used_ids = array();
+
+        if ( $nodes ) {
+            /** @var DOMElement $node */
+            foreach ( $nodes as $node ) {
+                $text = trim( wp_strip_all_tags( $dom->saveHTML( $node ) ) );
+                if ( '' === $text ) {
+                    continue;
+                }
+
+                $id = $node->getAttribute( 'id' );
+                if ( ! $id ) {
+                    $id = sanitize_title( $text );
+                }
+
+                $original_id = $id;
+                $i           = 2;
+                while ( in_array( $id, $used_ids, true ) ) {
+                    $id = $original_id . '-' . $i;
+                    $i++;
+                }
+
+                $used_ids[] = $id;
+                $node->setAttribute( 'id', $id );
+
+                $headings[] = array(
+                    'title' => $text,
+                    'id'    => $id,
+                    'level' => (int) substr( $node->nodeName, 1 ),
+                );
+            }
+        }
+
+        $body    = $dom->getElementsByTagName( 'body' )->item( 0 );
+        $updated = $content;
+
+        if ( $body ) {
+            $updated = '';
+            foreach ( $body->childNodes as $child ) {
+                $updated .= $dom->saveHTML( $child );
+            }
+        }
+
+        return array(
+            'headings' => $headings,
+            'content'  => $updated,
+        );
+    }
+}

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Debug logger.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Simple wrapper around error_log respecting WP_DEBUG.
+ */
+class Logger {
+
+    /**
+     * Log a message when debugging is enabled.
+     *
+     * @param string $message Message to log.
+     */
+    public static function log( string $message ): void {
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( '[Working with TOC] ' . $message );
+        }
+    }
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Main plugin bootstrap.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+use Working_With_TOC\Admin\Admin_Page;
+use Working_With_TOC\Frontend\Frontend;
+use Working_With_TOC\Heading_Parser;
+use Working_With_TOC\Structured_Data\Structured_Data_Manager;
+
+/**
+ * Plugin orchestrator.
+ */
+class Plugin {
+
+    /**
+     * Settings manager.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Admin UI handler.
+     *
+     * @var Admin_Page
+     */
+    protected $admin;
+
+    /**
+     * Frontend handler.
+     *
+     * @var Frontend
+     */
+    protected $frontend;
+
+    /**
+     * Structured data manager.
+     *
+     * @var Structured_Data_Manager
+     */
+    protected $structured_data;
+
+    /**
+     * Initialize plugin components.
+     */
+    public function init(): void {
+        $this->settings        = new Settings();
+        $this->admin           = new Admin_Page( $this->settings );
+        $this->frontend        = new Frontend( $this->settings );
+        $this->structured_data = new Structured_Data_Manager( $this->settings, $this->frontend );
+
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'admin_init', array( $this->settings, 'register' ) );
+        add_action( 'admin_menu', array( $this->admin, 'register_menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this->admin, 'enqueue_assets' ) );
+        add_action( 'wp_enqueue_scripts', array( $this->frontend, 'enqueue_assets' ) );
+        add_filter( 'the_content', array( $this->frontend, 'inject_toc' ), 15 );
+        add_action( 'wp_head', array( $this->structured_data, 'output_structured_data' ) );
+
+        // Rank Math compatibility hooks.
+        add_filter( 'rank_math/researches/toc_plugins', array( $this, 'register_rank_math_plugin' ) );
+        add_filter( 'rank_math/researches/toc_list', array( $this, 'register_rank_math_plugin' ) );
+        add_filter( 'rank_math/toc_plugins', array( $this, 'register_rank_math_plugin' ) );
+        add_filter( 'rank_math/researches/is_toc_plugin_active', array( $this, 'mark_rank_math_active' ), 10, 2 );
+        add_filter( 'rank_math/researches/is_toc_present', array( $this, 'mark_rank_math_presence' ), 10, 2 );
+
+        // Yoast SEO integration – ensure our schema can be merged safely.
+        add_filter( 'wpseo_schema_graph', array( $this->structured_data, 'filter_yoast_schema_graph' ) );
+
+        Logger::log( 'Plugin initialised.' );
+    }
+
+    /**
+     * Load text domain.
+     */
+    public function load_textdomain(): void {
+        load_plugin_textdomain( 'working-with-toc', false, dirname( plugin_basename( WWT_TOC_PLUGIN_FILE ) ) . '/languages' );
+    }
+
+    /**
+     * Register plugin name with Rank Math.
+     *
+     * @param array $plugins Registered plugins.
+     *
+     * @return array
+     */
+    public function register_rank_math_plugin( $plugins ): array {
+        if ( ! is_array( $plugins ) ) {
+            return $plugins;
+        }
+
+        $plugins['working-with-toc/working-with-toc.php'] = __( 'Working with TOC', 'working-with-toc' );
+
+        return $plugins;
+    }
+
+    /**
+     * Inform Rank Math that our plugin is active.
+     *
+     * @param bool   $is_active Whether Rank Math thinks the plugin is active.
+     * @param string $plugin    Plugin slug.
+     *
+     * @return bool
+     */
+    public function mark_rank_math_active( $is_active, $plugin ): bool {
+        if ( 'working-with-toc/working-with-toc.php' === $plugin ) {
+            return true;
+        }
+
+        return (bool) $is_active;
+    }
+
+    /**
+     * Help Rank Math detect our TOC within the analysed content.
+     *
+     * @param bool        $is_present Whether a TOC was detected.
+     * @param string|null $content    Analysed content.
+     *
+     * @return bool
+     */
+    public function mark_rank_math_presence( $is_present, $content = null ): bool {
+        if ( $is_present ) {
+            return true;
+        }
+
+        if ( is_string( $content ) ) {
+            if ( false !== strpos( $content, 'data-wwt-toc' ) ) {
+                return true;
+            }
+
+            $parsed = Heading_Parser::parse( $content );
+            if ( ! empty( $parsed['headings'] ) ) {
+                return true;
+            }
+        }
+
+        if ( is_singular() ) {
+            $post = get_post();
+            if ( $post && $this->settings->is_enabled_for( $post->post_type ) ) {
+                $parsed = Heading_Parser::parse( $post->post_content );
+                if ( ! empty( $parsed['headings'] ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return (bool) $is_present;
+    }
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Settings manager.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handle plugin settings persistence.
+ */
+class Settings {
+
+    /**
+     * Option name.
+     */
+    public const OPTION_NAME = 'wwt_toc_settings';
+
+    /**
+     * Get default settings.
+     *
+     * @return array
+     */
+    public function get_defaults(): array {
+        return array(
+            'enable_posts' => true,
+            'enable_pages'    => false,
+            'enable_products' => false,
+        );
+    }
+
+    /**
+     * Register settings with WordPress.
+     */
+    public function register(): void {
+        register_setting(
+            'wwt_toc_settings_group',
+            self::OPTION_NAME,
+            array(
+                'type'              => 'array',
+                'sanitize_callback' => array( $this, 'sanitize' ),
+                'default'           => $this->get_defaults(),
+            )
+        );
+    }
+
+    /**
+     * Get settings array.
+     *
+     * @return array
+     */
+    public function get_settings(): array {
+        $settings = get_option( self::OPTION_NAME, $this->get_defaults() );
+
+        return wp_parse_args( $settings, $this->get_defaults() );
+    }
+
+    /**
+     * Check if structured data is enabled for a post type.
+     *
+     * @param string $post_type Post type slug.
+     *
+     * @return bool
+     */
+    public function is_enabled_for( string $post_type ): bool {
+        $settings = $this->get_settings();
+
+        switch ( $post_type ) {
+            case 'page':
+                return ! empty( $settings['enable_pages'] );
+            case 'product':
+                return ! empty( $settings['enable_products'] );
+            default:
+                return ! empty( $settings['enable_posts'] );
+        }
+    }
+
+    /**
+     * Sanitize settings input.
+     *
+     * @param array $input Submitted values.
+     *
+     * @return array
+     */
+    public function sanitize( $input ): array {
+        $defaults = $this->get_defaults();
+        $output   = array();
+
+        foreach ( $defaults as $key => $default ) {
+            $output[ $key ] = isset( $input[ $key ] ) ? (bool) $input[ $key ] : false;
+        }
+
+        Logger::log( 'Settings saved: ' . wp_json_encode( $output ) );
+
+        return $output;
+    }
+}

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Frontend behaviour.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC\Frontend;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Post;
+use Working_With_TOC\Logger;
+use Working_With_TOC\Heading_Parser;
+use Working_With_TOC\Settings;
+
+/**
+ * Handles TOC injection and assets.
+ */
+class Frontend {
+
+    /**
+     * Settings.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Constructor.
+     *
+     * @param Settings $settings Settings handler.
+     */
+    public function __construct( Settings $settings ) {
+        $this->settings = $settings;
+    }
+
+    /**
+     * Enqueue frontend assets.
+     */
+    public function enqueue_assets(): void {
+        if ( ! is_singular() ) {
+            return;
+        }
+
+        $post = get_queried_object();
+        if ( $post instanceof WP_Post && ! $this->settings->is_enabled_for( $post->post_type ) ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'wwt-toc-frontend',
+            WWT_TOC_PLUGIN_URL . 'assets/css/frontend.css',
+            array(),
+            WWT_TOC_VERSION
+        );
+
+        wp_enqueue_script(
+            'wwt-toc-frontend',
+            WWT_TOC_PLUGIN_URL . 'assets/js/frontend.js',
+            array(),
+            WWT_TOC_VERSION,
+            true
+        );
+    }
+
+    /**
+     * Inject TOC markup into the content.
+     *
+     * @param string $content Post content.
+     *
+     * @return string
+     */
+    public function inject_toc( string $content ): string {
+        if ( ! is_singular() || ! in_the_loop() || ! is_main_query() ) {
+            return $content;
+        }
+
+        $post = get_post();
+        if ( ! $post instanceof WP_Post ) {
+            return $content;
+        }
+
+        if ( ! $this->settings->is_enabled_for( $post->post_type ) ) {
+            Logger::log( 'TOC disabled for post type: ' . $post->post_type );
+            return $content;
+        }
+
+        $result   = Heading_Parser::parse( $content );
+        $headings = $result['headings'];
+        $content  = $result['content'];
+
+        if ( empty( $headings ) ) {
+            Logger::log( 'No headings found for TOC.' );
+            return $content;
+        }
+
+        $toc_markup = $this->build_toc_markup( $headings );
+
+        return $content . $toc_markup;
+    }
+
+    /**
+     * Build TOC markup.
+     *
+     * @param array<int,array{title:string,id:string,level:int}> $headings Headings list.
+     *
+     * @return string
+     */
+    protected function build_toc_markup( array $headings ): string {
+        $items = '';
+        foreach ( $headings as $heading ) {
+            $indent = max( 0, $heading['level'] - 2 );
+            $items .= sprintf(
+                '<li class="wwt-level-%1$d"><a href="#%2$s">%3$s</a></li>',
+                (int) $indent,
+                esc_attr( $heading['id'] ),
+                esc_html( $heading['title'] )
+            );
+        }
+
+        $markup = sprintf(
+            '<div class="wwt-toc-container" data-wwt-toc data-expanded="false">
+                <button class="wwt-toc-toggle" type="button" aria-expanded="false">
+                    <span class="wwt-toc-label">%1$s</span>
+                    <span class="wwt-toc-icon" aria-hidden="true"></span>
+                </button>
+                <div class="wwt-toc-content" hidden>
+                    <nav class="wwt-toc-nav" aria-label="%1$s">
+                        <ol class="wwt-toc-list">%2$s</ol>
+                    </nav>
+                </div>
+            </div>',
+            esc_html__( 'Indice dei contenuti', 'working-with-toc' ),
+            $items
+        );
+
+        return $markup;
+    }
+}

--- a/includes/frontend/index.php
+++ b/includes/frontend/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Structured data output.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC\Structured_Data;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Post;
+use Working_With_TOC\Heading_Parser;
+use Working_With_TOC\Logger;
+use Working_With_TOC\Settings;
+use Working_With_TOC\Frontend\Frontend;
+
+/**
+ * Build structured data for TOC.
+ */
+class Structured_Data_Manager {
+
+    /**
+     * Settings handler.
+     *
+     * @var Settings
+     */
+    protected $settings;
+
+    /**
+     * Frontend handler.
+     *
+     * @var Frontend
+     */
+    protected $frontend;
+
+    /**
+     * Constructor.
+     *
+     * @param Settings $settings Settings handler.
+     * @param Frontend $frontend Frontend handler.
+     */
+    public function __construct( Settings $settings, Frontend $frontend ) {
+        $this->settings = $settings;
+        $this->frontend = $frontend;
+    }
+
+    /**
+     * Output JSON-LD for supported post types.
+     */
+    public function output_structured_data(): void {
+        if ( ! is_singular() ) {
+            return;
+        }
+
+        $post = get_post();
+        if ( ! $post instanceof WP_Post ) {
+            return;
+        }
+
+        if ( ! $this->settings->is_enabled_for( $post->post_type ) ) {
+            return;
+        }
+
+        $headings = $this->collect_headings( $post );
+        if ( empty( $headings ) ) {
+            return;
+        }
+
+        $schema = $this->build_schema( $post, $headings );
+
+        if ( empty( $schema ) ) {
+            return;
+        }
+
+        Logger::log( 'Rendering structured data for post ID ' . $post->ID );
+
+        echo '<script type="application/ld+json">' . wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) . '</script>' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    /**
+     * Integrate with Yoast schema graph.
+     *
+     * @param array $graph Existing graph.
+     *
+     * @return array
+     */
+    public function filter_yoast_schema_graph( $graph ): array {
+        if ( ! is_singular() ) {
+            return $graph;
+        }
+
+        $post = get_post();
+        if ( ! $post instanceof WP_Post || ! $this->settings->is_enabled_for( $post->post_type ) ) {
+            return $graph;
+        }
+
+        $headings = $this->collect_headings( $post );
+        if ( empty( $headings ) ) {
+            return $graph;
+        }
+
+        $schema = $this->build_schema( $post, $headings );
+        if ( empty( $schema ) ) {
+            return $graph;
+        }
+
+        $graph[] = $schema;
+        Logger::log( 'Merged TOC schema into Yoast graph for post ID ' . $post->ID );
+
+        return $graph;
+    }
+
+    /**
+     * Collect headings for the current post.
+     *
+     * @param WP_Post $post Post object.
+     *
+     * @return array<int, array{title:string, url:string}>
+     */
+    protected function collect_headings( WP_Post $post ): array {
+        $callback = array( $this->frontend, 'inject_toc' );
+        $priority = has_filter( 'the_content', $callback );
+
+        if ( false !== $priority ) {
+            remove_filter( 'the_content', $callback, (int) $priority );
+        }
+
+        $content = apply_filters( 'the_content', $post->post_content );
+
+        if ( false !== $priority ) {
+            add_filter( 'the_content', $callback, (int) $priority );
+        }
+
+        $parsed   = Heading_Parser::parse( $content );
+        $headings = array();
+
+        foreach ( $parsed['headings'] as $heading ) {
+            $headings[] = array(
+                'title' => $heading['title'],
+                'url'   => get_permalink( $post ) . '#' . $heading['id'],
+            );
+        }
+
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            Logger::log( 'Structured data headings raccolte: ' . count( $headings ) );
+        }
+
+        return $headings;
+    }
+
+    /**
+     * Build schema array for JSON-LD.
+     *
+     * @param WP_Post $post     Post object.
+     * @param array   $headings Headings with titles & URLs.
+     *
+     * @return array<string,mixed>
+     */
+    protected function build_schema( WP_Post $post, array $headings ): array {
+        $type = 'Article';
+        if ( 'product' === $post->post_type ) {
+            $type = 'Product';
+        } elseif ( 'page' === $post->post_type ) {
+            $type = 'WebPage';
+        }
+
+        $schema = array(
+            '@context' => 'https://schema.org',
+            '@type'    => $type,
+            '@id'      => get_permalink( $post ) . '#main',
+            'name'     => wp_strip_all_tags( get_the_title( $post ) ),
+            'url'      => get_permalink( $post ),
+            'hasPart'  => array(
+                '@type' => 'TableOfContents',
+                'name'  => __( 'Indice dei contenuti', 'working-with-toc' ),
+                'about' => array(),
+            ),
+        );
+
+        foreach ( $headings as $heading ) {
+            $schema['hasPart']['about'][] = array(
+                '@type' => 'Thing',
+                'name'  => $heading['title'],
+                'url'   => $heading['url'],
+            );
+        }
+
+        return $schema;
+    }
+}

--- a/includes/structured-data/index.php
+++ b/includes/structured-data/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Working with TOC
+ * Plugin URI:  https://example.com/working-with-toc
+ * Description: Table of Contents plugin with structured data controls and Rank Math / Yoast SEO compatibility.
+ * Version:     1.0.0
+ * Author:      Working with TOC Contributors
+ * Author URI:  https://example.com
+ * Text Domain: working-with-toc
+ * Domain Path: /languages
+ *
+ * @package Working_With_TOC
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'WWT_TOC_VERSION' ) ) {
+    define( 'WWT_TOC_VERSION', '1.0.0' );
+}
+
+define( 'WWT_TOC_PLUGIN_FILE', __FILE__ );
+define( 'WWT_TOC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WWT_TOC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once WWT_TOC_PLUGIN_DIR . 'includes/class-autoloader.php';
+
+Working_With_TOC\Autoloader::register();
+
+function working_with_toc() {
+    static $plugin = null;
+
+    if ( null === $plugin ) {
+        $plugin = new Working_With_TOC\Plugin();
+    }
+
+    return $plugin;
+}
+
+working_with_toc()->init();


### PR DESCRIPTION
## Summary
- bootstrap the plugin with an autoloader, shared heading parser, and dedicated classes for settings, admin UI, frontend rendering, and structured data
- add a stylized admin page to toggle TOC/structured data for posts, pages, and products with localized accessibility feedback
- render a sticky accordion TOC on the frontend, emit Rank Math/Yoast compatible structured data, and document the new structure in the README

## Testing
- `for file in $(find . -name '*.php'); do php -l "$file" >/dev/null || exit 1; done && echo 'All good'`


------
https://chatgpt.com/codex/tasks/task_e_68de529cd13483338cba26fee5dfd24d