### PR TITLE
Add structured data toggles to admin settings

### DIFF
--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -126,6 +126,35 @@ class Admin_Page {
                     </div>
                 </div>
 
+                <h2><?php esc_html_e( 'Dati strutturati TOC', 'working-with-toc' ); ?></h2>
+                <p><?php esc_html_e( 'Scegli dove includere lo schema JSON-LD generato dalla table of contents.', 'working-with-toc' ); ?></p>
+                <div class="wwt-toc-card-grid">
+                    <div class="wwt-toc-card">
+                        <h3><?php esc_html_e( 'Articoli', 'working-with-toc' ); ?></h3>
+                        <p><?php esc_html_e( 'Attiva i dati strutturati per i post del blog.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_posts]" value="1" <?php checked( $settings['structured_posts'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                    <div class="wwt-toc-card">
+                        <h3><?php esc_html_e( 'Pagine', 'working-with-toc' ); ?></h3>
+                        <p><?php esc_html_e( 'Abilita lo schema TOC per le pagine statiche.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_pages]" value="1" <?php checked( $settings['structured_pages'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                    <div class="wwt-toc-card">
+                        <h3><?php esc_html_e( 'Prodotti', 'working-with-toc' ); ?></h3>
+                        <p><?php esc_html_e( 'Integra i dati strutturati TOC nelle schede prodotto WooCommerce.', 'working-with-toc' ); ?></p>
+                        <label class="wwt-switch">
+                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_products]" value="1" <?php checked( $settings['structured_products'] ); ?>>
+                            <span class="wwt-slider"></span>
+                        </label>
+                    </div>
+                </div>
+
                 <div class="wwt-toc-submit">
                     <?php submit_button( __( 'Salva impostazioni', 'working-with-toc' ) ); ?>
                 </div>

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -26,9 +26,12 @@ class Settings {
      */
     public function get_defaults(): array {
         return array(
-            'enable_posts' => true,
-            'enable_pages'    => false,
-            'enable_products' => false,
+            'enable_posts'            => true,
+            'enable_pages'            => false,
+            'enable_products'         => false,
+            'structured_posts'        => false,
+            'structured_pages'        => false,
+            'structured_products'     => false,
         );
     }
 
@@ -75,6 +78,26 @@ class Settings {
                 return ! empty( $settings['enable_products'] );
             default:
                 return ! empty( $settings['enable_posts'] );
+        }
+    }
+
+    /**
+     * Check if structured data is enabled for a post type.
+     *
+     * @param string $post_type Post type slug.
+     *
+     * @return bool
+     */
+    public function is_structured_data_enabled_for( string $post_type ): bool {
+        $settings = $this->get_settings();
+
+        switch ( $post_type ) {
+            case 'page':
+                return ! empty( $settings['structured_pages'] );
+            case 'product':
+                return ! empty( $settings['structured_products'] );
+            default:
+                return ! empty( $settings['structured_posts'] );
         }
     }
 

--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -62,6 +62,10 @@ class Structured_Data_Manager {
             return;
         }
 
+        if ( ! $this->settings->is_structured_data_enabled_for( $post->post_type ) ) {
+            return;
+        }
+
         $headings = $this->collect_headings( $post );
         if ( empty( $headings ) ) {
             return;
@@ -92,6 +96,10 @@ class Structured_Data_Manager {
 
         $post = get_post();
         if ( ! $post instanceof WP_Post || ! $this->settings->is_enabled_for( $post->post_type ) ) {
+            return $graph;
+        }
+
+        if ( ! $this->settings->is_structured_data_enabled_for( $post->post_type ) ) {
             return $graph;
         }
 


### PR DESCRIPTION
## Summary
- add admin checkboxes to control TOC structured data for posts, pages, and products
- persist the new structured data settings and respect them when rendering JSON-LD

## Testing
- php -l includes/admin/class-admin-page.php
- php -l includes/class-settings.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68de57c68b9c8333bb549aa4a6e5bbbc