### PR TITLE
Add structured data toggles for each content type

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -83,6 +83,23 @@
     color: #52616b;
 }
 
+.wwt-toc-toggle-group {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.wwt-toc-toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.wwt-toc-toggle-label {
+    font-weight: 600;
+    color: #374151;
+}
+
 .wwt-switch {
     position: relative;
     display: inline-block;

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -103,26 +103,62 @@ class Admin_Page {
                     <div class="wwt-toc-card">
                         <h2><?php esc_html_e( 'Articoli', 'working-with-toc' ); ?></h2>
                         <p><?php esc_html_e( 'Abilita la TOC e i dati strutturati per i post standard.', 'working-with-toc' ); ?></p>
-                        <label class="wwt-switch">
-                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_posts]" value="1" <?php checked( $settings['enable_posts'] ); ?>>
-                            <span class="wwt-slider"></span>
-                        </label>
+                        <div class="wwt-toc-toggle-group">
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Indice dei contenuti', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_posts]" value="1" <?php checked( $settings['enable_posts'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Dati strutturati TOC', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_posts]" value="1" <?php checked( $settings['structured_posts'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                        </div>
                     </div>
                     <div class="wwt-toc-card">
                         <h2><?php esc_html_e( 'Pagine', 'working-with-toc' ); ?></h2>
                         <p><?php esc_html_e( 'Attiva la TOC per le pagine statiche del sito.', 'working-with-toc' ); ?></p>
-                        <label class="wwt-switch">
-                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_pages]" value="1" <?php checked( $settings['enable_pages'] ); ?>>
-                            <span class="wwt-slider"></span>
-                        </label>
+                        <div class="wwt-toc-toggle-group">
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Indice dei contenuti', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_pages]" value="1" <?php checked( $settings['enable_pages'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Dati strutturati TOC', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_pages]" value="1" <?php checked( $settings['structured_pages'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                        </div>
                     </div>
                     <div class="wwt-toc-card">
                         <h2><?php esc_html_e( 'Prodotti', 'working-with-toc' ); ?></h2>
                         <p><?php esc_html_e( 'Integrazione con WooCommerce per schede prodotto complete.', 'working-with-toc' ); ?></p>
-                        <label class="wwt-switch">
-                            <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_products]" value="1" <?php checked( $settings['enable_products'] ); ?>>
-                            <span class="wwt-slider"></span>
-                        </label>
+                        <div class="wwt-toc-toggle-group">
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Indice dei contenuti', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[enable_products]" value="1" <?php checked( $settings['enable_products'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                            <div class="wwt-toc-toggle-row">
+                                <span class="wwt-toc-toggle-label"><?php esc_html_e( 'Dati strutturati TOC', 'working-with-toc' ); ?></span>
+                                <label class="wwt-switch">
+                                    <input type="checkbox" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[structured_products]" value="1" <?php checked( $settings['structured_products'] ); ?>>
+                                    <span class="wwt-slider"></span>
+                                </label>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -26,9 +26,12 @@ class Settings {
      */
     public function get_defaults(): array {
         return array(
-            'enable_posts' => true,
-            'enable_pages'    => false,
-            'enable_products' => false,
+            'enable_posts'          => true,
+            'enable_pages'          => false,
+            'enable_products'       => false,
+            'structured_posts'      => true,
+            'structured_pages'      => false,
+            'structured_products'   => false,
         );
     }
 
@@ -59,7 +62,7 @@ class Settings {
     }
 
     /**
-     * Check if structured data is enabled for a post type.
+     * Check if the TOC is enabled for a post type.
      *
      * @param string $post_type Post type slug.
      *
@@ -75,6 +78,26 @@ class Settings {
                 return ! empty( $settings['enable_products'] );
             default:
                 return ! empty( $settings['enable_posts'] );
+        }
+    }
+
+    /**
+     * Check if structured data is enabled for a post type.
+     *
+     * @param string $post_type Post type slug.
+     *
+     * @return bool
+     */
+    public function is_structured_data_enabled_for( string $post_type ): bool {
+        $settings = $this->get_settings();
+
+        switch ( $post_type ) {
+            case 'page':
+                return ! empty( $settings['structured_pages'] );
+            case 'product':
+                return ! empty( $settings['structured_products'] );
+            default:
+                return ! empty( $settings['structured_posts'] );
         }
     }
 

--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -58,7 +58,7 @@ class Structured_Data_Manager {
             return;
         }
 
-        if ( ! $this->settings->is_enabled_for( $post->post_type ) ) {
+        if ( ! $this->settings->is_structured_data_enabled_for( $post->post_type ) ) {
             return;
         }
 
@@ -91,7 +91,7 @@ class Structured_Data_Manager {
         }
 
         $post = get_post();
-        if ( ! $post instanceof WP_Post || ! $this->settings->is_enabled_for( $post->post_type ) ) {
+        if ( ! $post instanceof WP_Post || ! $this->settings->is_structured_data_enabled_for( $post->post_type ) ) {
             return $graph;
         }
 


### PR DESCRIPTION
## Summary
- add dedicated structured data toggles for posts, pages, and products in the admin UI
- style the new toggle groups for consistent layout with existing switches
- persist the new structured data options and use them when rendering schema output

## Testing
- php -l includes/class-settings.php
- php -l includes/admin/class-admin-page.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68de57c68b9c8333bb549aa4a6e5bbbc