### PR TITLE
Allow filtering admin capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ working-with-toc/
 
 Nel menu di amministrazione viene aggiunta una pagina “Working with TOC” con tre card dedicate ai diversi tipi di contenuto. Ogni card include uno switch moderno per attivare o disattivare la TOC e i relativi dati strutturati. Il layout utilizza gradienti, ombre morbide e micro-animazioni per un aspetto premium.
 
+### Permessi personalizzati per la pagina impostazioni
+
+Il plugin utilizza la capability `manage_options` per impostazione predefinita, ma è possibile modificarla tramite il filtro `working_with_toc_admin_capability`. Ad esempio, per concedere l’accesso anche agli editor è sufficiente aggiungere al proprio tema o plugin:
+
+```php
+add_filter( 'working_with_toc_admin_capability', function ( $capability ) {
+    return 'edit_others_posts';
+} );
+```
+
+In questo modo la pagina **Working with TOC** sarà visibile a tutti gli utenti con la capability `edit_others_posts` (inclusi gli editor) mantenendo il comportamento originale per gli altri ruoli.
+
 ## Funzionalità frontend
 
 La TOC viene generata e mostrata in un accordion fissato al bordo inferiore della finestra. Gli utenti possono aprirla o chiuderla rapidamente; quando è aperta, il contenuto scorre all'interno di un pannello a scomparsa con evidenziazione dinamica della sezione in lettura grazie a `IntersectionObserver`.

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -25,12 +25,20 @@ class Admin_Page {
     protected $settings;
 
     /**
+     * Capability required to access the admin page.
+     *
+     * @var string
+     */
+    protected $capability;
+
+    /**
      * Constructor.
      *
      * @param Settings $settings Settings manager.
      */
     public function __construct( Settings $settings ) {
         $this->settings = $settings;
+        $this->capability = apply_filters( 'working_with_toc_admin_capability', 'manage_options' );
     }
 
     /**
@@ -40,7 +48,7 @@ class Admin_Page {
         add_menu_page(
             __( 'Working with TOC', 'working-with-toc' ),
             __( 'Working with TOC', 'working-with-toc' ),
-            'manage_options',
+            $this->capability,
             'working-with-toc',
             array( $this, 'render_page' ),
             'dashicons-list-view'
@@ -84,7 +92,7 @@ class Admin_Page {
      * Render settings page markup.
      */
     public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( $this->capability ) ) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- add a configurable capability property to the admin page and use it for menu registration and access checks
- document the new `working_with_toc_admin_capability` filter in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de59aaa68083338372cdc65147520f