### PR TITLE
Ensure administrators can access plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Nel menu di amministrazione viene aggiunta una pagina “Working with TOC” con
 
 ### Permessi personalizzati per la pagina impostazioni
 
-Il plugin utilizza la capability `manage_options` per impostazione predefinita, ma è possibile modificarla tramite il filtro `working_with_toc_admin_capability`. Ad esempio, per concedere l’accesso anche agli editor è sufficiente aggiungere al proprio tema o plugin:
+Il plugin registra la capability personalizzata `manage_working_with_toc` e la assegna automaticamente agli amministratori. È possibile modificarla tramite il filtro `working_with_toc_admin_capability`. Ad esempio, per concedere l’accesso anche agli editor è sufficiente aggiungere al proprio tema o plugin:
 
 ```php
 add_filter( 'working_with_toc_admin_capability', function ( $capability ) {

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -32,13 +32,31 @@ class Admin_Page {
     protected $capability;
 
     /**
+     * Default capability required to access the admin page.
+     */
+    public const DEFAULT_CAPABILITY = 'manage_working_with_toc';
+
+    /**
      * Constructor.
      *
      * @param Settings $settings Settings manager.
      */
     public function __construct( Settings $settings ) {
-        $this->settings = $settings;
-        $this->capability = apply_filters( 'working_with_toc_admin_capability', 'manage_options' );
+        $this->settings   = $settings;
+        $this->capability = $this->determine_capability();
+    }
+
+    /**
+     * Determine the capability required to access the admin page.
+     */
+    protected function determine_capability(): string {
+        $capability = apply_filters( 'working_with_toc_admin_capability', self::DEFAULT_CAPABILITY );
+
+        if ( ! is_string( $capability ) || '' === $capability ) {
+            $capability = self::DEFAULT_CAPABILITY;
+        }
+
+        return $capability;
     }
 
     /**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -57,6 +57,7 @@ class Plugin {
         $this->structured_data = new Structured_Data_Manager( $this->settings, $this->frontend );
 
         add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'init', array( $this, 'ensure_capability' ) );
         add_action( 'admin_init', array( $this->settings, 'register' ) );
         add_action( 'admin_menu', array( $this->admin, 'register_menu' ) );
         add_action( 'admin_enqueue_scripts', array( $this->admin, 'enqueue_assets' ) );
@@ -75,6 +76,21 @@ class Plugin {
         add_filter( 'wpseo_schema_graph', array( $this->structured_data, 'filter_yoast_schema_graph' ) );
 
         Logger::log( 'Plugin initialised.' );
+    }
+
+    /**
+     * Ensure administrators can manage the plugin settings.
+     */
+    public function ensure_capability(): void {
+        $role = \get_role( 'administrator' );
+
+        if ( ! $role ) {
+            return;
+        }
+
+        if ( ! $role->has_cap( Admin_Page::DEFAULT_CAPABILITY ) ) {
+            $role->add_cap( Admin_Page::DEFAULT_CAPABILITY );
+        }
     }
 
     /**

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -36,4 +36,13 @@ function working_with_toc() {
     return $plugin;
 }
 
+/**
+ * Run tasks on plugin activation.
+ */
+function working_with_toc_activate(): void {
+    working_with_toc()->ensure_capability();
+}
+
+register_activation_hook( __FILE__, 'working_with_toc_activate' );
+
 working_with_toc()->init();


### PR DESCRIPTION
## Summary
- add a dedicated `manage_working_with_toc` capability and fallback logic for the admin screen
- grant the capability to administrators on init and activation so the settings screen stays reachable
- document the new capability in the README

## Testing
- php -l working-with-toc/includes/admin/class-admin-page.php
- php -l working-with-toc/includes/class-plugin.php
- php -l working-with-toc/working-with-toc.php

------
https://chatgpt.com/codex/tasks/task_e_68de5adb43488333923daf34f5be6a31