### PR TITLE
Ensure TOC shortcode placement under the first heading

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -58,6 +58,7 @@ class Plugin {
 
         add_action( 'init', array( $this, 'load_textdomain' ) );
         add_action( 'init', array( $this, 'ensure_capability' ) );
+        add_action( 'init', array( $this->frontend, 'register_shortcode' ) );
         add_action( 'admin_init', array( $this->settings, 'register' ) );
         add_action( 'admin_menu', array( $this->admin, 'register_menu' ) );
         add_action( 'admin_enqueue_scripts', array( $this->admin, 'enqueue_assets' ) );


### PR DESCRIPTION
## Summary
- register the `[working_with_toc]` shortcode and swap it with the generated TOC markup
- automatically insert the TOC after the first H2–H5 heading when the shortcode is not present
- hook shortcode registration into the plugin bootstrap so it works on posts, pages, and products

## Testing
- php -l includes/frontend/class-frontend.php
- php -l includes/class-plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68de5f81a4b08333af737ef561e4e3b1