### PR TITLE
Fix TOC injection guard for block themes

### DIFF
--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -98,7 +98,19 @@ class Frontend {
      * @return string
      */
     public function inject_toc( string $content ): string {
-        if ( ! is_singular() || ! in_the_loop() || ! is_main_query() ) {
+        if ( ! is_singular() || ! is_main_query() ) {
+            return $content;
+        }
+
+        if ( is_feed() ) {
+            return $content;
+        }
+
+        if ( function_exists( 'wp_is_json_request' ) && wp_is_json_request() ) {
+            return $content;
+        }
+
+        if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
             return $content;
         }
 


### PR DESCRIPTION
## Summary
- allow the TOC injector to run on block themes by dropping the in_the_loop() gate while keeping the singular/main query checks
- avoid injecting the TOC when generating feeds, REST responses, or JSON requests

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de62b18d7c8333afc1581c9959747f