### PR TITLE
Add TOC positioning controls and improve styling UX

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -60,6 +60,7 @@
     inset: 0;
     background: linear-gradient(135deg, rgba(95,93,239,0.1), rgba(127,83,172,0.15));
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.25s ease;
 }
 
@@ -207,6 +208,29 @@
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
 
+.wwt-toc-style__layout {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.wwt-toc-style__layout label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.wwt-toc-style__layout select {
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid rgba(15, 23, 42, 0.15);
+    padding: 0.45rem 0.6rem;
+    background: #ffffff;
+    color: #111827;
+}
+
 .wwt-toc-style__color {
     display: flex;
     flex-direction: column;
@@ -327,6 +351,26 @@
     font-family: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
     font-size: 0.82rem;
     color: #374151;
+}
+
+.wwt-toc-meta__layout {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.wwt-toc-meta__layout label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.wwt-toc-meta__layout select {
+    width: 100%;
+    border-radius: 6px;
+    border: 1px solid #d1d5db;
+    padding: 0.35rem 0.45rem;
 }
 
 .wwt-toc-meta__headings-list {

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -4,13 +4,16 @@
     --wwt-toc-title-color: #f8fafc;
     --wwt-toc-text: #e2e8f0;
     --wwt-toc-link: #38bdf8;
+    --wwt-toc-translate-x: -50%;
+    --wwt-toc-translate-y: 0;
     position: fixed;
-    left: 1.5rem;
-    right: 1.5rem;
-    bottom: 1.5rem;
     z-index: 9999;
-    max-width: 420px;
-    margin: 0 auto;
+    left: 50%;
+    right: auto;
+    bottom: 1.5rem;
+    top: auto;
+    width: min(420px, calc(100vw - 3rem));
+    margin: 0;
     background-color: var(--wwt-toc-bg);
     background-image: radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 55%);
     color: var(--wwt-toc-text);
@@ -20,19 +23,40 @@
     backdrop-filter: blur(16px);
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
+    transform: translate3d(var(--wwt-toc-translate-x), var(--wwt-toc-translate-y), 0);
 }
 
 .wwt-toc-container:hover {
-    transform: translateY(-2px);
+    transform: translate3d(var(--wwt-toc-translate-x), calc(var(--wwt-toc-translate-y) - 2px), 0);
     box-shadow: 0 32px 60px rgba(15, 23, 42, 0.45);
 }
 
-@media (min-width: 960px) {
-    .wwt-toc-container {
-        left: auto;
-        right: 2rem;
-        margin: 0;
-    }
+.wwt-toc-container[data-align-x="left"] {
+    left: 1.5rem;
+    right: auto;
+    --wwt-toc-translate-x: 0;
+}
+
+.wwt-toc-container[data-align-x="right"] {
+    right: 1.5rem;
+    left: auto;
+    --wwt-toc-translate-x: 0;
+}
+
+.wwt-toc-container[data-align-x="center"] {
+    left: 50%;
+    right: auto;
+    --wwt-toc-translate-x: -50%;
+}
+
+.wwt-toc-container[data-align-y="top"] {
+    top: 1.5rem;
+    bottom: auto;
+}
+
+.wwt-toc-container[data-align-y="bottom"] {
+    bottom: 1.5rem;
+    top: auto;
 }
 
 .wwt-toc-toggle {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -13,6 +13,23 @@
         return;
     }
 
+    const applyContainerColors = (container) => {
+        const map = {
+            bg: '--wwt-toc-bg',
+            text: '--wwt-toc-text',
+            link: '--wwt-toc-link',
+            titleBg: '--wwt-toc-title-bg',
+            titleColor: '--wwt-toc-title-color',
+        };
+
+        Object.entries(map).forEach(([dataKey, cssVar]) => {
+            const value = container.dataset[dataKey];
+            if (value) {
+                container.style.setProperty(cssVar, value);
+            }
+        });
+    };
+
     const togglePanel = (container, expanded) => {
         const button = container.querySelector('.wwt-toc-toggle');
         const panel = container.querySelector('.wwt-toc-content');
@@ -27,13 +44,17 @@
     };
 
     containers.forEach((container) => {
+        applyContainerColors(container);
+
         const button = container.querySelector('.wwt-toc-toggle');
         const panel = container.querySelector('.wwt-toc-content');
-        const links = panel ? Array.from(panel.querySelectorAll('a[href^="#"]')) : [];
 
         if (!button || !panel) {
             return;
         }
+
+        const expanded = container.dataset.expanded === 'true';
+        togglePanel(container, expanded);
 
         button.addEventListener('click', () => {
             const expanded = container.dataset.expanded === 'true';
@@ -45,12 +66,6 @@
                 togglePanel(container, false);
             }
         });
-
-        if (links.length) {
-            links.forEach((link) => {
-                link.addEventListener('click', () => togglePanel(container, false));
-            });
-        }
     });
 
     const highlightActiveHeading = () => {

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -154,11 +154,26 @@ class Admin_Page {
                     'text_color'             => __( 'Colore del testo', 'working-with-toc' ),
                     'link_color'             => __( 'Colore dei link', 'working-with-toc' ),
                 );
+
+                $horizontal_options = array(
+                    'left'   => __( 'Sinistra', 'working-with-toc' ),
+                    'center' => __( 'Centro', 'working-with-toc' ),
+                    'right'  => __( 'Destra', 'working-with-toc' ),
+                );
+
+                $vertical_options = array(
+                    'top'    => __( 'In alto', 'working-with-toc' ),
+                    'bottom' => __( 'In basso', 'working-with-toc' ),
+                );
                 ?>
                 <div class="wwt-toc-card-grid">
                     <?php foreach ( $cards as $prefix => $card ) :
                         $title_field_name = sprintf( '%s[%s_title]', Settings::OPTION_NAME, $prefix );
                         $title_field_id   = sprintf( 'wwt_toc_%s_title', $prefix );
+                        $horizontal_field_name = sprintf( '%s[%s_horizontal_alignment]', Settings::OPTION_NAME, $prefix );
+                        $horizontal_field_id   = sprintf( 'wwt_toc_%s_horizontal_alignment', $prefix );
+                        $vertical_field_name   = sprintf( '%s[%s_vertical_alignment]', Settings::OPTION_NAME, $prefix );
+                        $vertical_field_id     = sprintf( 'wwt_toc_%s_vertical_alignment', $prefix );
                         ?>
                         <div class="wwt-toc-card">
                             <h2><?php echo esc_html( $card['heading'] ); ?></h2>
@@ -197,6 +212,24 @@ class Admin_Page {
                                             <input type="color" id="<?php echo esc_attr( $field_id ); ?>" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $settings[ $prefix . '_' . $field ] ); ?>" />
                                         </div>
                                     <?php endforeach; ?>
+                                </div>
+                                <div class="wwt-toc-style__layout">
+                                    <div class="wwt-toc-style__layout-field">
+                                        <label for="<?php echo esc_attr( $horizontal_field_id ); ?>"><?php esc_html_e( 'Posizione orizzontale', 'working-with-toc' ); ?></label>
+                                        <select id="<?php echo esc_attr( $horizontal_field_id ); ?>" name="<?php echo esc_attr( $horizontal_field_name ); ?>">
+                                            <?php foreach ( $horizontal_options as $value => $label ) : ?>
+                                                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $settings[ $prefix . '_horizontal_alignment' ], $value ); ?>><?php echo esc_html( $label ); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div class="wwt-toc-style__layout-field">
+                                        <label for="<?php echo esc_attr( $vertical_field_id ); ?>"><?php esc_html_e( 'Posizione verticale', 'working-with-toc' ); ?></label>
+                                        <select id="<?php echo esc_attr( $vertical_field_id ); ?>" name="<?php echo esc_attr( $vertical_field_name ); ?>">
+                                            <?php foreach ( $vertical_options as $value => $label ) : ?>
+                                                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $settings[ $prefix . '_vertical_alignment' ], $value ); ?>><?php echo esc_html( $label ); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/includes/admin/class-meta-box.php
+++ b/includes/admin/class-meta-box.php
@@ -109,6 +109,27 @@ class Meta_Box {
             }
         }
 
+        $horizontal_alignment = $defaults['horizontal_alignment'];
+        if ( isset( $meta['horizontal_alignment'] ) ) {
+            $horizontal_alignment = $this->settings->sanitize_horizontal_alignment( $meta['horizontal_alignment'], $horizontal_alignment );
+        }
+
+        $vertical_alignment = $defaults['vertical_alignment'];
+        if ( isset( $meta['vertical_alignment'] ) ) {
+            $vertical_alignment = $this->settings->sanitize_vertical_alignment( $meta['vertical_alignment'], $vertical_alignment );
+        }
+
+        $horizontal_options = array(
+            'left'   => __( 'Sinistra', 'working-with-toc' ),
+            'center' => __( 'Centro', 'working-with-toc' ),
+            'right'  => __( 'Destra', 'working-with-toc' ),
+        );
+
+        $vertical_options = array(
+            'top'    => __( 'In alto', 'working-with-toc' ),
+            'bottom' => __( 'In basso', 'working-with-toc' ),
+        );
+
         $headings = $this->get_headings( $post );
         $excluded = $this->sanitize_heading_ids( $meta['excluded_headings'] ?? array() );
         ?>
@@ -139,6 +160,28 @@ class Meta_Box {
                             <span class="wwt-toc-meta__color-value" data-target="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( strtoupper( $value ) ); ?></span>
                         </div>
                     <?php endforeach; ?>
+                </div>
+            </div>
+
+            <div class="wwt-toc-meta__group">
+                <span class="wwt-toc-meta__label"><?php esc_html_e( 'Posizionamento della TOC', 'working-with-toc' ); ?></span>
+                <div class="wwt-toc-meta__layout">
+                    <label for="wwt_toc_meta_horizontal_alignment">
+                        <?php esc_html_e( 'Posizione orizzontale', 'working-with-toc' ); ?>
+                        <select id="wwt_toc_meta_horizontal_alignment" name="wwt_toc_meta[horizontal_alignment]">
+                            <?php foreach ( $horizontal_options as $value => $label ) : ?>
+                                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $horizontal_alignment, $value ); ?>><?php echo esc_html( $label ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <label for="wwt_toc_meta_vertical_alignment">
+                        <?php esc_html_e( 'Posizione verticale', 'working-with-toc' ); ?>
+                        <select id="wwt_toc_meta_vertical_alignment" name="wwt_toc_meta[vertical_alignment]">
+                            <?php foreach ( $vertical_options as $value => $label ) : ?>
+                                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $vertical_alignment, $value ); ?>><?php echo esc_html( $label ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
                 </div>
             </div>
 
@@ -214,6 +257,22 @@ class Meta_Box {
 
             if ( strtolower( $value ) !== strtolower( $defaults[ $field ] ) ) {
                 $data[ $field ] = $value;
+            }
+        }
+
+        if ( isset( $input['horizontal_alignment'] ) ) {
+            $alignment = $this->settings->sanitize_horizontal_alignment( wp_unslash( $input['horizontal_alignment'] ), $defaults['horizontal_alignment'] );
+
+            if ( $alignment !== $defaults['horizontal_alignment'] ) {
+                $data['horizontal_alignment'] = $alignment;
+            }
+        }
+
+        if ( isset( $input['vertical_alignment'] ) ) {
+            $alignment = $this->settings->sanitize_vertical_alignment( wp_unslash( $input['vertical_alignment'] ), $defaults['vertical_alignment'] );
+
+            if ( $alignment !== $defaults['vertical_alignment'] ) {
+                $data['vertical_alignment'] = $alignment;
             }
         }
 


### PR DESCRIPTION
## Summary
- add alignment selectors for default settings and per-post TOC customisation
- ensure admin styling inputs remain clickable and update layout styling helpers
- keep the TOC accordion open by default, preserve it after link clicks, and inject colours via container ids/data attributes

## Testing
- php -l includes/class-settings.php
- php -l includes/admin/class-admin-page.php
- php -l includes/admin/class-meta-box.php
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68de70ff9dc483339eda1ea6b60197ab