### PR TITLE
Update plugin metadata and enforce namespaces

### DIFF
--- a/assets/css/index.php
+++ b/assets/css/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/assets/js/index.php
+++ b/assets/js/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/includes/admin/index.php
+++ b/includes/admin/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/includes/frontend/index.php
+++ b/includes/frontend/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/includes/structured-data/index.php
+++ b/includes/structured-data/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/index.php
+++ b/index.php
@@ -1,2 +1,7 @@
 <?php
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
 // Silence is golden.

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -1,48 +1,67 @@
 <?php
 /**
  * Plugin Name: Working with TOC
- * Plugin URI:  https://example.com/working-with-toc
+ * Plugin URI:  https://workingwithweb.it/webagency
  * Description: Table of Contents plugin with structured data controls and Rank Math / Yoast SEO compatibility.
  * Version:     1.0.0
- * Author:      Working with TOC Contributors
- * Author URI:  https://example.com
+ * Author:      Alfonso Vertucci - Working with Web
+ * Author URI:  https://workingwithweb.it/webagency
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
  * Text Domain: working-with-toc
  * Domain Path: /languages
  *
  * @package Working_With_TOC
  */
 
-defined( 'ABSPATH' ) || exit;
+namespace Working_With_TOC {
 
-if ( ! defined( 'WWT_TOC_VERSION' ) ) {
-    define( 'WWT_TOC_VERSION', '1.0.0' );
-}
+    defined( 'ABSPATH' ) || exit;
 
-define( 'WWT_TOC_PLUGIN_FILE', __FILE__ );
-define( 'WWT_TOC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-define( 'WWT_TOC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-
-require_once WWT_TOC_PLUGIN_DIR . 'includes/class-autoloader.php';
-
-Working_With_TOC\Autoloader::register();
-
-function working_with_toc() {
-    static $plugin = null;
-
-    if ( null === $plugin ) {
-        $plugin = new Working_With_TOC\Plugin();
+    if ( ! defined( 'WWT_TOC_VERSION' ) ) {
+        define( 'WWT_TOC_VERSION', '1.0.0' );
     }
 
-    return $plugin;
+    define( 'WWT_TOC_PLUGIN_FILE', __FILE__ );
+    define( 'WWT_TOC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+    define( 'WWT_TOC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+    require_once WWT_TOC_PLUGIN_DIR . 'includes/class-autoloader.php';
+
+    Autoloader::register();
+
+    function working_with_toc() {
+        static $plugin = null;
+
+        if ( null === $plugin ) {
+            $plugin = new Plugin();
+        }
+
+        return $plugin;
+    }
+
+    /**
+     * Run tasks on plugin activation.
+     */
+    function working_with_toc_activate(): void {
+        working_with_toc()->ensure_capability();
+    }
+
+    \register_activation_hook( __FILE__, __NAMESPACE__ . '\\working_with_toc_activate' );
+
+    working_with_toc()->init();
 }
 
-/**
- * Run tasks on plugin activation.
- */
-function working_with_toc_activate(): void {
-    working_with_toc()->ensure_capability();
+namespace {
+
+    if ( ! function_exists( 'working_with_toc' ) ) {
+        /**
+         * Provide a global helper for backward compatibility.
+         *
+         * @return \Working_With_TOC\Plugin
+         */
+        function working_with_toc() {
+            return \Working_With_TOC\working_with_toc();
+        }
+    }
 }
-
-register_activation_hook( __FILE__, 'working_with_toc_activate' );
-
-working_with_toc()->init();


### PR DESCRIPTION
## Summary
- update the plugin header to credit Alfonso Vertucci of Working with Web and declare minimum WordPress/PHP versions
- wrap the bootstrap file in the plugin namespace while keeping a global helper for backwards compatibility
- add the plugin namespace and ABSPATH guard to every PHP index file

## Testing
- php -l working-with-toc.php
- php -l index.php includes/index.php includes/admin/index.php includes/frontend/index.php includes/structured-data/index.php assets/index.php assets/css/index.php assets/js/index.php

------
https://chatgpt.com/codex/tasks/task_e_68de74c3ff58833389e58abc6cfbd5bf