### PR TITLE
Add translated WordPress readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,20 +9,43 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
-Working with TOC adds a modern, mobile-friendly table of contents to posts, pages, and WooCommerce products.
-It integrates with Rank Math and Yoast SEO by generating structured data and custom anchors that stay in sync with the page headings.
+Working with TOC creates a polished, mobile-friendly table of contents (TOC) for articles, pages, and WooCommerce products.
+The plugin respects WordPress coding conventions, splits responsibilities across dedicated folders, and integrates with Rank Math and Yoast SEO.
+
+= Key Features =
+* Sticky accordion TOC fixed to the bottom of the viewport with touch-friendly controls.
+* Automatic heading anchor generation (`<h2>`–`<h6>`) that keeps TOC links synchronized with on-page headings.
+* Admin page with toggles to enable the TOC and Schema.org `TableOfContents` data by post type.
+* JSON-LD output compatible with Rank Math and Yoast SEO schema graphs, avoiding duplicate markup.
+* Conditional logging that respects the `WP_DEBUG` flag for safe troubleshooting in development environments.
+
+= Admin Permissions =
+The plugin registers the custom capability `manage_working_with_toc`. Administrators receive it automatically, and you can modify access via the `working_with_toc_admin_capability` filter:
+
+```
+add_filter( 'working_with_toc_admin_capability', function ( $capability ) {
+    return 'edit_others_posts';
+} );
+```
 
 == Installation ==
-1. Upload the `working-with-toc` folder to the `/wp-content/plugins/` directory or install via the WordPress admin.
-2. Activate the plugin through the "Plugins" menu in WordPress.
-3. Visit **Settings → Working with TOC** to configure where the table of contents and structured data should appear.
+1. Upload the `working-with-toc` folder to `/wp-content/plugins/` or install it from the WordPress admin.
+2. Activate the plugin through the **Plugins** menu.
+3. Visit **Settings → Working with TOC** to decide where the TOC and structured data should be enabled.
 
 == Frequently Asked Questions ==
 = Which post types are supported? =
-Articles, pages, and WooCommerce products can generate the table of contents and structured data.
+Posts, pages, and WooCommerce products can generate the table of contents and structured data.
 
 = Does the plugin add schema markup? =
-Yes. The plugin outputs a TableOfContents node that integrates with Rank Math or Yoast SEO schema graphs.
+Yes. The plugin outputs a Schema.org `TableOfContents` node that integrates with Rank Math or Yoast SEO graphs.
+
+= What are the minimum requirements? =
+Working with TOC requires WordPress 6.0 or higher and PHP 7.4 or higher, and it is released under the GPLv2 or later license.
+
+== Screenshots ==
+1. Sticky accordion TOC displayed on the frontend.
+2. Settings page with post-type specific toggles.
 
 == Changelog ==
 = 1.0.0 =
@@ -30,4 +53,4 @@ Yes. The plugin outputs a TableOfContents node that integrates with Rank Math or
 
 == Upgrade Notice ==
 = 1.0.0 =
-Initial public release.
+Initial public release under the GPLv2 or later license.


### PR DESCRIPTION
## Summary
- expand the WordPress readme with an English translation of the project overview and key features
- document admin capabilities, installation steps, and minimum requirements including GPL licensing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7da3be7c8333b33a25c2f868c0d5