### PR TITLE
Enhance uninstall cleanup

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -4,8 +4,31 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 global $wpdb;
-$table_name = $wpdb->prefix . 'working_with_toc';
 
-$wpdb->query( "DROP TABLE IF EXISTS $table_name" );
+if ( isset( $wpdb ) && property_exists( $wpdb, 'prefix' ) ) {
+    $table_name = $wpdb->prefix . 'working_with_toc';
+    $wpdb->query( "DROP TABLE IF EXISTS $table_name" );
+}
 
-delete_option( 'wwtoc_db_version' );
+if ( function_exists( 'delete_option' ) ) {
+    delete_option( 'wwtoc_db_version' );
+    delete_option( 'wwt_toc_settings' );
+}
+
+if ( function_exists( 'delete_metadata' ) ) {
+    delete_metadata( 'post', 0, '_wwt_toc_meta', '', true );
+}
+
+if ( function_exists( 'wp_roles' ) ) {
+    $wp_roles = wp_roles();
+
+    if ( $wp_roles && is_object( $wp_roles ) && method_exists( $wp_roles, 'get_role' ) && property_exists( $wp_roles, 'roles' ) && is_array( $wp_roles->roles ) ) {
+        foreach ( $wp_roles->roles as $role_name => $role_info ) {
+            $role = $wp_roles->get_role( $role_name );
+
+            if ( $role && method_exists( $role, 'remove_cap' ) && isset( $role->capabilities['manage_working_with_toc'] ) ) {
+                $role->remove_cap( 'manage_working_with_toc' );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the uninstall routine removes plugin options and metadata
- remove the custom capability from all roles during uninstall
- add defensive checks before calling WordPress APIs during uninstall

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8fc3c20c833385f1d10b51db6a92