### PR TITLE
Remove unused database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Panoramica
 
 **Working with TOC** è un plugin WordPress pensato per creare automaticamente un indice dei contenuti elegante e mobile-friendly per articoli, pagine e prodotti. Il progetto dimostra una suddivisione del codice secondo le convenzioni WordPress (cartelle `includes/`, `admin/`, `frontend/`, `assets/`) e include strumenti per generare dati strutturati compatibili con Rank Math e Yoast SEO.
+La configurazione viene salvata attraverso le normali opzioni e i meta di WordPress, senza creare tabelle personalizzate o opzioni di versioning dedicate.
 
 ## Caratteristiche principali
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 == Description ==
 Working with TOC creates a polished, mobile-friendly table of contents (TOC) for articles, pages, and WooCommerce products.
 The plugin respects WordPress coding conventions, splits responsibilities across dedicated folders, and integrates with Rank Math and Yoast SEO.
+It stores its configuration using standard WordPress options and post meta, without creating custom database tables or version-tracking options.
 
 = Key Features =
 * Sticky accordion TOC fixed to the bottom of the viewport with touch-friendly controls.

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,15 +3,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit;
 }
 
-global $wpdb;
-
-if ( isset( $wpdb ) && property_exists( $wpdb, 'prefix' ) ) {
-    $table_name = $wpdb->prefix . 'working_with_toc';
-    $wpdb->query( "DROP TABLE IF EXISTS $table_name" );
-}
-
 if ( function_exists( 'delete_option' ) ) {
-    delete_option( 'wwtoc_db_version' );
     delete_option( 'wwt_toc_settings' );
 }
 

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -47,28 +47,6 @@ namespace Working_With_TOC {
      */
     function working_with_toc_activate(): void {
         working_with_toc()->ensure_capability();
-
-        global $wpdb;
-
-        $installed_version = get_option( 'wwtoc_db_version' );
-        $current_version   = WWTOC_VERSION;
-
-        if ( $installed_version !== $current_version ) {
-            $table_name      = $wpdb->prefix . 'working_with_toc';
-            $charset_collate = $wpdb->get_charset_collate();
-
-            $sql = "CREATE TABLE $table_name (
-            id mediumint(9) NOT NULL AUTO_INCREMENT,
-            title text NOT NULL,
-            created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
-            PRIMARY KEY  (id)
-        ) $charset_collate;";
-
-            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-            \dbDelta( $sql );
-
-            update_option( 'wwtoc_db_version', $current_version );
-        }
     }
 
     \register_activation_hook( __FILE__, __NAMESPACE__ . '\\working_with_toc_activate' );


### PR DESCRIPTION
## Summary
- remove the activation routine that managed the custom `working_with_toc` table and its version option
- simplify the uninstall script to keep only option, meta, and capability cleanup
- clarify in the documentation that the plugin stores data using standard WordPress options and meta only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9043d01c833392201166bb3bb663