### PR TITLE
Handle missing DOM extension gracefully

### DIFF
--- a/includes/class-heading-parser.php
+++ b/includes/class-heading-parser.php
@@ -26,6 +26,13 @@ class Heading_Parser {
      * @return array{headings:array<int,array{title:string,id:string,level:int}>,content:string}
      */
     public static function parse( string $content ): array {
+        if ( ! class_exists( '\\DOMDocument' ) || is_domdocument_missing() ) {
+            return array(
+                'headings' => array(),
+                'content'  => $content,
+            );
+        }
+
         $dom       = new DOMDocument();
         $previous = libxml_use_internal_errors( true );
         $dom->loadHTML( '<?xml encoding="utf-8"?>' . $content );

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -15,6 +15,7 @@ use WP_Post;
 use Working_With_TOC\Logger;
 use Working_With_TOC\Heading_Parser;
 use Working_With_TOC\Settings;
+use function Working_With_TOC\is_domdocument_missing;
 
 /**
  * Handles TOC injection and assets.
@@ -111,6 +112,10 @@ class Frontend {
         }
 
         if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+            return $content;
+        }
+
+        if ( is_domdocument_missing() ) {
             return $content;
         }
 
@@ -442,6 +447,10 @@ class Frontend {
      * @return string|null Updated content when a heading is found, otherwise null.
      */
     protected function insert_toc_after_first_heading( string $content, string $toc_markup ): ?string {
+        if ( is_domdocument_missing() || ! class_exists( '\\DOMDocument' ) ) {
+            return $content;
+        }
+
         $dom       = new DOMDocument();
         $previous  = libxml_use_internal_errors( true );
         $loaded    = $dom->loadHTML( '<?xml encoding="utf-8"?>' . $content );

--- a/includes/functions-dependencies.php
+++ b/includes/functions-dependencies.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Dependency helpers.
+ *
+ * @package Working_With_TOC
+ */
+
+namespace Working_With_TOC;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Check whether the DOMDocument dependency is missing.
+ */
+function is_domdocument_missing(): bool {
+    return ! empty( $GLOBALS['wwt_toc_missing_domdocument'] );
+}
+
+/**
+ * Render an admin notice when DOMDocument is unavailable.
+ */
+function render_missing_domdocument_notice(): void {
+    if ( ! is_domdocument_missing() ) {
+        return;
+    }
+
+    if ( ! current_user_can( 'activate_plugins' ) ) {
+        return;
+    }
+
+    printf(
+        '<div class="notice notice-error"><p>%s</p></div>',
+        esc_html__( 'Working with TOC requires the PHP DOM extension. Please enable the DOM extension to use the plugin.', 'working-with-toc' )
+    );
+}

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -29,8 +29,21 @@ namespace Working_With_TOC {
     define( 'WWT_TOC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
     require_once WWT_TOC_PLUGIN_DIR . 'includes/class-autoloader.php';
+    require_once WWT_TOC_PLUGIN_DIR . 'includes/functions-dependencies.php';
 
     Autoloader::register();
+
+    global $wwt_toc_missing_domdocument;
+
+    if ( ! isset( $wwt_toc_missing_domdocument ) ) {
+        $wwt_toc_missing_domdocument = false;
+    }
+
+    if ( ! class_exists( '\\DOMDocument' ) ) {
+        $wwt_toc_missing_domdocument = true;
+        add_action( 'admin_notices', __NAMESPACE__ . '\\render_missing_domdocument_notice' );
+        return;
+    }
 
     function working_with_toc() {
         static $plugin = null;


### PR DESCRIPTION
## Summary
- stop plugin bootstrap when the DOM extension is unavailable and flag the missing dependency
- add a shared helper and admin notice to highlight the DOMDocument requirement
- short-circuit DOM-dependent parsing to return the original content when the dependency is absent

## Testing
- php -l working-with-toc.php
- php -l includes/functions-dependencies.php
- php -l includes/class-heading-parser.php
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68de90f0811c833392fc7c760191a19d