### PR TITLE
Harden color sanitization in meta box

### DIFF
--- a/includes/admin/class-meta-box.php
+++ b/includes/admin/class-meta-box.php
@@ -103,7 +103,12 @@ class Meta_Box {
                 continue;
             }
 
-            $sanitised = sanitize_hex_color( $meta[ $key ] );
+            $value = $meta[ $key ];
+            if ( ! is_string( $value ) ) {
+                continue;
+            }
+
+            $sanitised = sanitize_hex_color( $value );
             if ( $sanitised ) {
                 $colors[ $key ] = $sanitised;
             }
@@ -249,7 +254,16 @@ class Meta_Box {
         }
 
         foreach ( array( 'title_color', 'title_background_color', 'background_color', 'text_color', 'link_color' ) as $field ) {
-            $value = isset( $input[ $field ] ) ? sanitize_hex_color( wp_unslash( $input[ $field ] ) ) : '';
+            if ( ! isset( $input[ $field ] ) ) {
+                continue;
+            }
+
+            $raw_value = wp_unslash( $input[ $field ] );
+            if ( ! is_string( $raw_value ) ) {
+                continue;
+            }
+
+            $value = sanitize_hex_color( $raw_value );
 
             if ( ! $value ) {
                 continue;


### PR DESCRIPTION
## Summary
- guard the meta box color rendering against non-string values before sanitizing
- ensure meta box save handler validates color fields as strings prior to calling sanitize_hex_color

## Testing
- php -l includes/admin/class-meta-box.php

------
https://chatgpt.com/codex/tasks/task_e_68de8d6890508333a317e319092d88d4