### PR TITLE
Integrate TOC schema into Rank Math JSON-LD graph

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -84,6 +84,7 @@ class Plugin {
         add_filter( 'rank_math/toc_plugins', array( $this, 'register_rank_math_plugin' ) );
         add_filter( 'rank_math/researches/is_toc_plugin_active', array( $this, 'mark_rank_math_active' ), 10, 2 );
         add_filter( 'rank_math/researches/is_toc_present', array( $this, 'mark_rank_math_presence' ), 10, 2 );
+        add_filter( 'rank_math/json_ld', array( $this->structured_data, 'filter_rank_math_json_ld' ), 10, 2 );
 
         // Yoast SEO integration – ensure our schema can be merged safely.
         add_filter( 'wpseo_schema_graph', array( $this->structured_data, 'filter_yoast_schema_graph' ) );


### PR DESCRIPTION
## Summary
- add a Rank Math json_ld filter that injects the TOC schema into the existing graph
- cache the generated schema per post and reuse it for direct output and Yoast integration
- skip emitting a standalone JSON-LD script when Rank Math is active to avoid duplicate markup

## Testing
- php -l includes/class-plugin.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68de96651e1883339af7525a5fd01bd9