### PR TITLE
Replace unsupported TableOfContents schema with ItemList

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ La configurazione viene salvata attraverso le normali opzioni e i meta di WordPr
 - Accordion TOC fisso nella parte inferiore dello schermo con design moderno e supporto touch.
 - Generazione automatica degli anchor ID sui titoli `<h2>-<h6>` e sincronizzazione con gli URL della TOC.
 - Pannello di amministrazione personalizzato con interruttori per attivare TOC e dati strutturati per articoli, pagine e prodotti WooCommerce.
-- Output JSON-LD dedicato al tipo `TableOfContents` per articoli, pagine e prodotti, integrato nel grafo schema di Yoast SEO e riconosciuto da Rank Math.
+- Output JSON-LD compatibile basato su `ItemList` per articoli, pagine e prodotti, integrato nel grafo schema di Yoast SEO e riconosciuto da Rank Math.
 - Logging condizionato sul flag `WP_DEBUG` per agevolare il debug senza inquinare l'ambiente di produzione.
 
 ## Struttura del plugin
@@ -74,7 +74,7 @@ La TOC viene generata e mostrata in un accordion fissato al bordo inferiore dell
 
 - **Rank Math**: il plugin si registra tra i TOC supportati, evitando l’avviso “Nessun plugin TOC installato”.
 - **Yoast SEO**: i dati strutturati vengono aggiunti al grafo esistente tramite il filtro `wpseo_schema_graph` senza conflitti.
-- **Schema.org**: viene generato un nodo `TableOfContents` con riferimenti diretti alle intestazioni del contenuto, con URL coerenti con l’anchor ID generato nel markup.
+- **Schema.org**: viene generato un nodo `ItemList` con riferimenti diretti alle intestazioni del contenuto, con URL coerenti con l’anchor ID generato nel markup.
 
 ## Log e debug
 

--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -262,17 +262,21 @@ class Structured_Data_Manager {
             'name'     => wp_strip_all_tags( get_the_title( $post ) ),
             'url'      => get_permalink( $post ),
             'hasPart'  => array(
-                '@type' => 'TableOfContents',
-                'name'  => $toc_title,
-                'about' => array(),
+                '@type'           => 'ItemList',
+                'name'            => $toc_title,
+                'itemListElement' => array(),
             ),
         );
 
-        foreach ( $headings as $heading ) {
-            $schema['hasPart']['about'][] = array(
-                '@type' => 'Thing',
-                'name'  => $heading['title'],
-                'url'   => $heading['url'],
+        foreach ( $headings as $index => $heading ) {
+            $schema['hasPart']['itemListElement'][] = array(
+                '@type'    => 'ListItem',
+                'position' => $index + 1,
+                'item'     => array(
+                    '@type' => 'Thing',
+                    'name'  => $heading['title'],
+                    'url'   => $heading['url'],
+                ),
             );
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ It stores its configuration using standard WordPress options and post meta, with
 = Key Features =
 * Sticky accordion TOC fixed to the bottom of the viewport with touch-friendly controls.
 * Automatic heading anchor generation (`<h2>`–`<h6>`) that keeps TOC links synchronized with on-page headings.
-* Admin page with toggles to enable the TOC and Schema.org `TableOfContents` data by post type.
+* Admin page with toggles to enable the TOC and Schema.org `ItemList` data by post type.
 * JSON-LD output compatible with Rank Math and Yoast SEO schema graphs, avoiding duplicate markup.
 * Conditional logging that respects the `WP_DEBUG` flag for safe troubleshooting in development environments.
 
@@ -39,7 +39,7 @@ add_filter( 'working_with_toc_admin_capability', function ( $capability ) {
 Posts, pages, and WooCommerce products can generate the table of contents and structured data.
 
 = Does the plugin add schema markup? =
-Yes. The plugin outputs a Schema.org `TableOfContents` node that integrates with Rank Math or Yoast SEO graphs.
+Yes. The plugin outputs a Schema.org `ItemList` node that integrates with Rank Math or Yoast SEO graphs.
 
 = What are the minimum requirements? =
 Working with TOC requires WordPress 6.0 or higher and PHP 7.4 or higher, and it is released under the GPLv2 or later license.


### PR DESCRIPTION
## Summary
- replace the JSON-LD `TableOfContents` node with an `ItemList` representation that uses `ListItem` entries with positions and URLs for each heading
- refresh project documentation to describe the new `ItemList` structured data output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9ae385308333a11e36a3ca1275fc