### PR TITLE
Add fallback structured data controls and schema graph

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -37,6 +37,32 @@
     color: var(--wwt-text);
 }
 
+.wwt-toc-organization {
+    margin-top: 2.5rem;
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 14px;
+    padding: 1.5rem 1.75rem;
+    box-shadow: 0 15px 35px rgba(15, 23, 42, 0.12);
+}
+
+.wwt-toc-organization__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem 1.5rem;
+    margin-top: 1rem;
+}
+
+.wwt-toc-organization__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.wwt-toc-organization__field label {
+    font-weight: 600;
+    color: #0f172a;
+}
+
 .wwt-toc-card-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -231,6 +257,44 @@
     color: #111827;
 }
 
+.wwt-toc-structured-data {
+    margin-top: 1.5rem;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    background: rgba(59, 130, 246, 0.05);
+    border: 1px solid rgba(59, 130, 246, 0.12);
+}
+
+.wwt-toc-structured-data__title {
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.wwt-toc-structured-data__hint {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.wwt-toc-structured-data__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.85rem;
+}
+
+.wwt-toc-structured-data__field label {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.wwt-toc-structured-data__field input,
+.wwt-toc-structured-data__field textarea {
+    width: 100%;
+}
+
 .wwt-toc-style__color {
     display: flex;
     flex-direction: column;
@@ -371,6 +435,18 @@
     border-radius: 6px;
     border: 1px solid #d1d5db;
     padding: 0.35rem 0.45rem;
+}
+
+.wwt-toc-meta__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+}
+
+.wwt-toc-meta__field input,
+.wwt-toc-meta__field textarea {
+    width: 100%;
 }
 
 .wwt-toc-meta__headings-list {

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -174,6 +174,12 @@ class Admin_Page {
                         $horizontal_field_id   = sprintf( 'wwt_toc_%s_horizontal_alignment', $prefix );
                         $vertical_field_name   = sprintf( '%s[%s_vertical_alignment]', Settings::OPTION_NAME, $prefix );
                         $vertical_field_id     = sprintf( 'wwt_toc_%s_vertical_alignment', $prefix );
+                        $headline_field_name   = sprintf( '%s[%s_schema_fallback_headline]', Settings::OPTION_NAME, $prefix );
+                        $headline_field_id     = sprintf( 'wwt_toc_%s_schema_fallback_headline', $prefix );
+                        $description_field_name = sprintf( '%s[%s_schema_fallback_description]', Settings::OPTION_NAME, $prefix );
+                        $description_field_id   = sprintf( 'wwt_toc_%s_schema_fallback_description', $prefix );
+                        $image_field_name       = sprintf( '%s[%s_schema_fallback_image]', Settings::OPTION_NAME, $prefix );
+                        $image_field_id         = sprintf( 'wwt_toc_%s_schema_fallback_image', $prefix );
                         ?>
                         <div class="wwt-toc-card">
                             <h2><?php echo esc_html( $card['heading'] ); ?></h2>
@@ -232,6 +238,23 @@ class Admin_Page {
                                     </div>
                                 </div>
                             </div>
+
+                            <div class="wwt-toc-structured-data">
+                                <h3 class="wwt-toc-structured-data__title"><?php esc_html_e( 'Base structured data defaults', 'working-with-toc' ); ?></h3>
+                                <p class="wwt-toc-structured-data__hint"><?php esc_html_e( 'These values are used when the automatic headline, description, or image cannot be detected.', 'working-with-toc' ); ?></p>
+                                <div class="wwt-toc-structured-data__field">
+                                    <label for="<?php echo esc_attr( $headline_field_id ); ?>"><?php esc_html_e( 'Fallback headline', 'working-with-toc' ); ?></label>
+                                    <input type="text" id="<?php echo esc_attr( $headline_field_id ); ?>" name="<?php echo esc_attr( $headline_field_name ); ?>" value="<?php echo esc_attr( $settings[ $prefix . '_schema_fallback_headline' ] ); ?>" class="widefat" />
+                                </div>
+                                <div class="wwt-toc-structured-data__field">
+                                    <label for="<?php echo esc_attr( $description_field_id ); ?>"><?php esc_html_e( 'Fallback description', 'working-with-toc' ); ?></label>
+                                    <textarea id="<?php echo esc_attr( $description_field_id ); ?>" name="<?php echo esc_attr( $description_field_name ); ?>" rows="3" class="widefat"><?php echo esc_textarea( $settings[ $prefix . '_schema_fallback_description' ] ); ?></textarea>
+                                </div>
+                                <div class="wwt-toc-structured-data__field">
+                                    <label for="<?php echo esc_attr( $image_field_id ); ?>"><?php esc_html_e( 'Fallback image URL', 'working-with-toc' ); ?></label>
+                                    <input type="url" id="<?php echo esc_attr( $image_field_id ); ?>" name="<?php echo esc_attr( $image_field_name ); ?>" value="<?php echo esc_attr( $settings[ $prefix . '_schema_fallback_image' ] ); ?>" class="widefat" />
+                                </div>
+                            </div>
                         </div>
                     <?php endforeach; ?>
                 </div>
@@ -240,6 +263,24 @@ class Admin_Page {
                     <?php submit_button( __( 'Save settings', 'working-with-toc' ) ); ?>
                 </div>
             </form>
+            <section class="wwt-toc-organization">
+                <h2><?php esc_html_e( 'Organization structured data', 'working-with-toc' ); ?></h2>
+                <p><?php esc_html_e( 'Customise the organisation details used for fallback structured data output.', 'working-with-toc' ); ?></p>
+                <div class="wwt-toc-organization__grid">
+                    <div class="wwt-toc-organization__field">
+                        <label for="wwt_toc_organization_name"><?php esc_html_e( 'Organization name', 'working-with-toc' ); ?></label>
+                        <input type="text" id="wwt_toc_organization_name" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_name]" value="<?php echo esc_attr( $settings['organization_name'] ); ?>" class="regular-text" />
+                    </div>
+                    <div class="wwt-toc-organization__field">
+                        <label for="wwt_toc_organization_url"><?php esc_html_e( 'Organization URL', 'working-with-toc' ); ?></label>
+                        <input type="url" id="wwt_toc_organization_url" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_url]" value="<?php echo esc_attr( $settings['organization_url'] ); ?>" class="regular-text" />
+                    </div>
+                    <div class="wwt-toc-organization__field">
+                        <label for="wwt_toc_organization_logo"><?php esc_html_e( 'Logo URL', 'working-with-toc' ); ?></label>
+                        <input type="url" id="wwt_toc_organization_logo" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_logo]" value="<?php echo esc_attr( $settings['organization_logo'] ); ?>" class="regular-text" />
+                    </div>
+                </div>
+            </section>
             <footer class="wwt-toc-footer">
                 <p><?php esc_html_e( 'Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events.', 'working-with-toc' ); ?></p>
             </footer>


### PR DESCRIPTION
## Summary
- add organization-level defaults and per-content fallback values for the structured data output
- expand the editor meta box with headline, description, and image overrides for base schema fields
- emit a complete fallback JSON-LD graph (WebPage, Article, BreadcrumbList, Organization, ItemList) when no SEO plugin is active and refresh the admin UI styling

## Testing
- php -l includes/class-settings.php
- php -l includes/admin/class-admin-page.php
- php -l includes/admin/class-meta-box.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68de9cc92ce08333a972229a652df1b8