### PR TITLE
Improve TOC semantics and accessibility

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -59,32 +59,44 @@
     top: auto;
 }
 
-.wwt-toc-toggle {
+.wwt-toc-header {
+    position: relative;
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    width: 100%;
     background: var(--wwt-toc-title-bg) !important;
-    border: none;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
     color: var(--wwt-toc-title-color) !important;
     padding: 1rem 1.25rem;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.wwt-toc-heading {
+    margin: 0;
     font-size: 1.05rem;
     font-weight: 600;
     letter-spacing: 0.01em;
+    text-transform: uppercase;
+    flex: 1;
+    padding-right: 2.75rem;
+}
+
+.wwt-toc-toggle {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    background: transparent;
+    border: none;
+    color: inherit;
+    padding: 0 1.25rem;
     cursor: pointer;
+    z-index: 1;
 }
 
 .wwt-toc-toggle:focus,
 .wwt-toc-toggle:focus-visible {
     outline: 2px solid var(--wwt-toc-link);
     outline-offset: 2px;
-}
-
-.wwt-toc-label {
-    text-transform: uppercase;
-    font-size: 0.85rem;
-    letter-spacing: 0.08em;
 }
 
 .wwt-toc-icon {

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -201,8 +201,9 @@ class Frontend {
             : __( 'Table of contents', 'working-with-toc' );
 
         $container_id         = $this->get_container_id( $post_id );
+        $heading_id           = $container_id . '-heading';
         $toggle_id            = $container_id . '-toggle';
-        $title_id             = $container_id . '-title';
+        $toggle_hint_id       = $toggle_id . '-hint';
         $content_id           = $container_id . '-content';
         $container_attributes = $this->build_container_attributes( $preferences, $post_id );
         $toggle_attributes    = $this->stringify_attributes(
@@ -212,20 +213,21 @@ class Frontend {
                 'type'            => 'button',
                 'aria-expanded'   => 'true',
                 'aria-controls'   => $content_id,
-                'aria-labelledby' => $title_id,
+                'aria-labelledby' => $heading_id,
+                'aria-describedby' => $toggle_hint_id,
             )
         );
-        $label_attributes     = $this->stringify_attributes(
+        $heading_attributes   = $this->stringify_attributes(
             array(
-                'id'    => $title_id,
-                'class' => 'wwt-toc-label',
+                'id'    => $heading_id,
+                'class' => 'wwt-toc-heading',
             )
         );
         $content_attributes   = $this->stringify_attributes(
             array(
                 'id'              => $content_id,
                 'class'           => 'wwt-toc-content',
-                'aria-labelledby' => $title_id,
+                'aria-labelledby' => $heading_id,
             )
         );
 
@@ -233,20 +235,25 @@ class Frontend {
 
         $markup = sprintf(
             '<div %1$s>' .
-                '<button %2$s>' .
-                    '<span %3$s>%4$s</span>' .
-                    '<span class="wwt-toc-icon" aria-hidden="true"></span>' .
-                '</button>' .
-                '<div %5$s>' .
-                    '<nav class="wwt-toc-nav" aria-label="%6$s">' .
-                        '<ol class="wwt-toc-list">%7$s</ol>' .
+                '<div class="wwt-toc-header">' .
+                    '<h2 %2$s>%3$s</h2>' .
+                    '<button %4$s>' .
+                        '<span id="%5$s" class="screen-reader-text">%6$s</span>' .
+                        '<span class="wwt-toc-icon" aria-hidden="true"></span>' .
+                    '</button>' .
+                '</div>' .
+                '<div %7$s>' .
+                    '<nav class="wwt-toc-nav" aria-label="%8$s" role="doc-toc">' .
+                        '<ol class="wwt-toc-list">%9$s</ol>' .
                     '</nav>' .
                 '</div>' .
             '</div>',
             $container_attributes,
-            $toggle_attributes,
-            $label_attributes,
+            $heading_attributes,
             esc_html( $label ),
+            $toggle_attributes,
+            esc_attr( $toggle_hint_id ),
+            esc_html__( 'Toggle table of contents visibility', 'working-with-toc' ),
             $content_attributes,
             esc_attr( $label ),
             $items


### PR DESCRIPTION
## Summary
- render the TOC heading with an actual <h2> and associate the toggle button and panel with it
- add an accessible description for the toggle button and doc-toc role on the navigation list
- restyle the header layout so the new heading remains visible without changing the toggle interaction

## Testing
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dea0fa01388333a74af10a3ccc6a35