### PR TITLE
Improve automatic structured data fallbacks

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -341,10 +341,18 @@ class Settings {
         $settings = $this->get_settings();
         $prefix   = $this->get_style_prefix( $post_type );
 
+        $headline    = $settings[ $prefix . '_schema_fallback_headline' ] ?? '';
+        $description = $settings[ $prefix . '_schema_fallback_description' ] ?? '';
+        $image       = $settings[ $prefix . '_schema_fallback_image' ] ?? '';
+
+        if ( '' === $image ) {
+            $image = $this->get_default_schema_image_url();
+        }
+
         return array(
-            'headline'    => $settings[ $prefix . '_schema_fallback_headline' ] ?? '',
-            'description' => $settings[ $prefix . '_schema_fallback_description' ] ?? '',
-            'image'       => $settings[ $prefix . '_schema_fallback_image' ] ?? '',
+            'headline'    => $headline,
+            'description' => $description,
+            'image'       => $image,
         );
     }
 
@@ -544,6 +552,33 @@ class Settings {
         }
 
         return $url;
+    }
+
+    /**
+     * Get the default image URL used for schema fallbacks.
+     */
+    public function get_default_schema_image_url(): string {
+        $organization = $this->get_organization_settings();
+
+        if ( ! empty( $organization['logo'] ) && is_string( $organization['logo'] ) ) {
+            $logo = esc_url_raw( $organization['logo'] );
+
+            if ( '' !== $logo ) {
+                return $logo;
+            }
+        }
+
+        $site_icon = function_exists( 'get_site_icon_url' ) ? get_site_icon_url() : '';
+
+        if ( is_string( $site_icon ) ) {
+            $site_icon = esc_url_raw( $site_icon );
+
+            if ( '' !== $site_icon ) {
+                return $site_icon;
+            }
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
## Summary
- derive fallback schema headline, description, and image directly from WordPress data when SEO plugins are inactive
- expose a reusable default schema image helper so meta boxes and runtime fallbacks share the same logo-based backup

## Testing
- php -l includes/structured-data/class-structured-data-manager.php
- php -l includes/admin/class-meta-box.php
- php -l includes/class-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68dea3c5afd48333bb52a360dd31190c