### PR TITLE
Add plugin imagery references and enhance admin branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ La configurazione viene salvata attraverso le normali opzioni e i meta di WordPr
 - Output JSON-LD compatibile basato su `ItemList` per articoli, pagine e prodotti, integrato nel grafo schema di Yoast SEO e riconosciuto da Rank Math.
 - Logging condizionato sul flag `WP_DEBUG` per agevolare il debug senza inquinare l'ambiente di produzione.
 
+## Screenshot
+
+![Sticky accordion TOC displayed on the frontend](assets/images/screeshort-1.png)
+
+![Settings page with post-type specific toggles](assets/images/assets/screenshot-2.png)
+
+![Organization structured data defaults configured in the admin](assets/images/screenshot-3.png)
+
 ## Struttura del plugin
 
 ```

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -188,10 +188,92 @@
 }
 
 .wwt-toc-footer {
-    margin-top: 1.5rem;
-    text-align: center;
+    margin-top: 2rem;
+    padding: 1.75rem 2rem;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(93, 95, 239, 0.95), rgba(127, 83, 172, 0.9));
+    color: rgba(255, 255, 255, 0.92);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.wwt-toc-footer__branding {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1.25rem;
+    text-align: left;
+}
+
+.wwt-toc-footer__logo {
+    width: 72px;
+    height: 72px;
+    border-radius: 18px;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+    background-color: rgba(255, 255, 255, 0.85);
+    object-fit: contain;
+    padding: 0.4rem;
+}
+
+.wwt-toc-footer__summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.wwt-toc-footer__title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #ffffff;
+}
+
+.wwt-toc-footer__description {
+    margin: 0;
     font-size: 0.95rem;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.wwt-toc-footer__details {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem 1rem;
+    font-size: 0.9rem;
+}
+
+.wwt-toc-footer__details strong {
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.wwt-toc-footer__details a {
+    color: #f4f5ff;
+    text-decoration: underline;
+}
+
+.wwt-toc-footer__details a:hover,
+.wwt-toc-footer__details a:focus {
+    color: #ffffff;
+}
+
+@media (max-width: 782px) {
+    .wwt-toc-footer {
+        padding: 1.5rem;
+    }
+
+    .wwt-toc-footer__branding {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .wwt-toc-footer__details {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
 }
 
 .wwt-toc-style {

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -60,6 +60,29 @@ class Admin_Page {
     }
 
     /**
+     * Retrieve plugin metadata for the footer.
+     */
+    protected function get_plugin_metadata(): array {
+        if ( ! function_exists( 'get_plugin_data' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        $raw_data = get_plugin_data( WWT_TOC_PLUGIN_FILE, false, false );
+
+        return array(
+            'name'         => $raw_data['Name'] ?? __( 'Working with TOC', 'working-with-toc' ),
+            'description'  => isset( $raw_data['Description'] ) ? wp_strip_all_tags( $raw_data['Description'] ) : '',
+            'version'      => $raw_data['Version'] ?? WWTOC_VERSION,
+            'author'       => $raw_data['AuthorName'] ?? '',
+            'author_url'   => $raw_data['AuthorURI'] ?? '',
+            'plugin_url'   => $raw_data['PluginURI'] ?? '',
+            'license'      => $raw_data['License'] ?? 'GPLv2 or later',
+            'requires_wp'  => $raw_data['RequiresWP'] ?? '',
+            'requires_php' => $raw_data['RequiresPHP'] ?? '',
+        );
+    }
+
+    /**
      * Register menu item.
      */
     public function register_menu(): void {
@@ -69,7 +92,7 @@ class Admin_Page {
             $this->capability,
             'working-with-toc',
             array( $this, 'render_page' ),
-            'dashicons-list-view'
+            WWT_TOC_PLUGIN_URL . 'assets/images/www-logo.png'
         );
     }
 
@@ -115,6 +138,8 @@ class Admin_Page {
         }
 
         $settings = $this->settings->get_settings();
+        $metadata = $this->get_plugin_metadata();
+        $logo_url = WWT_TOC_PLUGIN_URL . 'assets/images/www-logo.png';
         Logger::log( 'Rendering settings page.' );
         ?>
         <div class="wrap wwt-toc-admin">
@@ -282,7 +307,37 @@ class Admin_Page {
                 </div>
             </section>
             <footer class="wwt-toc-footer">
-                <p><?php esc_html_e( 'Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events.', 'working-with-toc' ); ?></p>
+                <div class="wwt-toc-footer__branding">
+                    <img class="wwt-toc-footer__logo" src="<?php echo esc_url( $logo_url ); ?>" alt="<?php esc_attr_e( 'Working with Web logo', 'working-with-toc' ); ?>" />
+                    <div class="wwt-toc-footer__summary">
+                        <h3 class="wwt-toc-footer__title"><?php echo esc_html( $metadata['name'] ); ?></h3>
+                        <?php if ( '' !== $metadata['description'] ) : ?>
+                            <p class="wwt-toc-footer__description"><?php echo esc_html( $metadata['description'] ); ?></p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <ul class="wwt-toc-footer__details">
+                    <li><strong><?php esc_html_e( 'Version:', 'working-with-toc' ); ?></strong> <?php echo esc_html( $metadata['version'] ); ?></li>
+                    <?php if ( '' !== $metadata['author'] ) : ?>
+                        <li><strong><?php esc_html_e( 'Author:', 'working-with-toc' ); ?></strong>
+                            <?php if ( '' !== $metadata['author_url'] ) : ?>
+                                <a href="<?php echo esc_url( $metadata['author_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $metadata['author'] ); ?></a>
+                            <?php else : ?>
+                                <?php echo esc_html( $metadata['author'] ); ?>
+                            <?php endif; ?>
+                        </li>
+                    <?php endif; ?>
+                    <?php if ( '' !== $metadata['plugin_url'] ) : ?>
+                        <li><strong><?php esc_html_e( 'Plugin URI:', 'working-with-toc' ); ?></strong> <a href="<?php echo esc_url( $metadata['plugin_url'] ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View plugin page', 'working-with-toc' ); ?></a></li>
+                    <?php endif; ?>
+                    <li><strong><?php esc_html_e( 'License:', 'working-with-toc' ); ?></strong> <?php echo esc_html( $metadata['license'] ); ?></li>
+                    <?php if ( '' !== $metadata['requires_wp'] ) : ?>
+                        <li><strong><?php esc_html_e( 'Requires WordPress:', 'working-with-toc' ); ?></strong> <?php echo esc_html( $metadata['requires_wp'] ); ?></li>
+                    <?php endif; ?>
+                    <?php if ( '' !== $metadata['requires_php'] ) : ?>
+                        <li><strong><?php esc_html_e( 'Requires PHP:', 'working-with-toc' ); ?></strong> <?php echo esc_html( $metadata['requires_php'] ); ?></li>
+                    <?php endif; ?>
+                </ul>
             </footer>
         </div>
         <?php

--- a/readme-it_IT.txt
+++ b/readme-it_IT.txt
@@ -49,9 +49,13 @@ Working with TOC richiede WordPress 6.0 o superiore e PHP 7.4 o superiore ed è 
 = Il plugin è compatibile con WordPress multisite? =
 Sì. Il plugin è stato verificato nelle reti multisite. Puoi attivarlo per singolo sito per impostazioni indipendenti oppure attivarlo a livello di rete per rendere disponibile la pagina di amministrazione su tutti i siti, mantenendo comunque configurazioni indipendenti.
 
-== Screenshot ==
+== Screenshots ==
 1. Sommario a fisarmonica fissato sul frontend.
+   ![Sommario a fisarmonica fissato sul frontend](assets/images/screeshort-1.png)
 2. Pagina delle impostazioni con interruttori specifici per tipo di contenuto.
+   ![Pagina delle impostazioni con interruttori specifici per tipo di contenuto](assets/images/assets/screenshot-2.png)
+3. Configurazione dei dati strutturati dell'organizzazione nella pagina di amministrazione.
+   ![Configurazione dei dati strutturati dell'organizzazione nella pagina di amministrazione](assets/images/screenshot-3.png)
 
 == Changelog ==
 = 1.0.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,11 @@ Yes. The plugin has been verified on multisite networks. You can activate it per
 
 == Screenshots ==
 1. Sticky accordion TOC displayed on the frontend.
+   ![Sticky accordion TOC displayed on the frontend](assets/images/screeshort-1.png)
 2. Settings page with post-type specific toggles.
+   ![Settings page with post-type specific toggles](assets/images/assets/screenshot-2.png)
+3. Organization structured data defaults configured in the admin.
+   ![Organization structured data defaults configured in the admin](assets/images/screenshot-3.png)
 
 == Changelog ==
 = 1.0.0 =

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -6,6 +6,7 @@
  * Version:     1.0.0
  * Author:      Alfonso Vertucci - Working with Web
  * Author URI:  https://workingwithweb.it/webagency
+ * Icon URI:    assets/images/www-logo.png
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * Text Domain: working-with-toc


### PR DESCRIPTION
## Summary
- embed plugin screenshot assets in the English and Italian readme files as well as the project README
- register the custom logo as the admin menu icon and display enriched plugin metadata with branding in the settings footer
- refresh admin styles to support the new footer layout and highlight the logo asset path in the plugin header

## Testing
- php -l includes/admin/class-admin-page.php
- php -l working-with-toc.php

------
https://chatgpt.com/codex/tasks/task_e_68deaf93aa4c8333a54c9b71b5f84ef5