### PR TITLE
Add logo image to readme headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Working with TOC logo](assets/images/www-logo.png)
+
 # Working with TOC
 
 ## Sommario

--- a/readme-it_IT.txt
+++ b/readme-it_IT.txt
@@ -1,3 +1,5 @@
+![Working with TOC logo](assets/images/www-logo.png)
+
 === Working with TOC ===
 Contributors: workingwithweb
 Tags: sommario, indice dei contenuti, seo, accessibilità, dati strutturati, multisite

--- a/readme.txt
+++ b/readme.txt
@@ -1,3 +1,5 @@
+![Working with TOC logo](assets/images/www-logo.png)
+
 === Working with TOC ===
 Contributors: workingwithweb
 Tags: table of contents, seo, accessibility, structured data, multisite


### PR DESCRIPTION
## Summary
- add the plugin logo image to the top of the Markdown README
- include the logo image at the top of both English and Italian WordPress readmes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68deb14e4a4c833384e65a5e32823796