### PR TITLE
Fix readme header position for WordPress parser

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,5 @@
-![Working with TOC logo](assets/images/www-logo.png)
-
 === Working with TOC ===
+
 Contributors: workingwithweb
 Tags: table of contents, seo, accessibility, structured data, multisite
 Requires at least: 6.0
@@ -11,6 +10,8 @@ License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Create a responsive, sticky table of contents with SEO-ready structured data.
+
+![Working with TOC logo](assets/images/www-logo.png)
 
 == Description ==
 Working with TOC creates a polished, mobile-friendly table of contents (TOC) for articles, pages, and WooCommerce products.


### PR DESCRIPTION
## Summary
- ensure the plugin readme starts with the header so the WordPress parser detects metadata
- relocate the Markdown logo to appear below the short description

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deba7c94288333b24c91f3dc16e521