### PR TITLE
Use class constant for DOMDocument availability checks

### DIFF
--- a/includes/class-heading-parser.php
+++ b/includes/class-heading-parser.php
@@ -26,7 +26,7 @@ class Heading_Parser {
      * @return array{headings:array<int,array{title:string,id:string,level:int}>,content:string}
      */
     public static function parse( string $content ): array {
-        if ( ! class_exists( '\\DOMDocument' ) || is_domdocument_missing() ) {
+        if ( ! class_exists( \DOMDocument::class ) || is_domdocument_missing() ) {
             return array(
                 'headings' => array(),
                 'content'  => $content,

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -454,7 +454,7 @@ class Frontend {
      * @return string|null Updated content when a heading is found, otherwise null.
      */
     protected function insert_toc_after_first_heading( string $content, string $toc_markup ): ?string {
-        if ( is_domdocument_missing() || ! class_exists( '\\DOMDocument' ) ) {
+        if ( is_domdocument_missing() || ! class_exists( \DOMDocument::class ) ) {
             return $content;
         }
 

--- a/working-with-toc.php
+++ b/working-with-toc.php
@@ -40,7 +40,7 @@ namespace Working_With_TOC {
         $wwt_toc_missing_domdocument = false;
     }
 
-    if ( ! class_exists( '\\DOMDocument' ) ) {
+    if ( ! class_exists( \DOMDocument::class ) ) {
         $wwt_toc_missing_domdocument = true;
         add_action( 'admin_notices', __NAMESPACE__ . '\\render_missing_domdocument_notice' );
         return;


### PR DESCRIPTION
## Summary
- update DOMDocument availability checks in the bootstrap, heading parser, and frontend to use the class constant

## Testing
- php /tmp/test-plugin.php

------
https://chatgpt.com/codex/tasks/task_e_68debd29ebb883339e07191d4f73317d