### PR TITLE
Update translation template and locale catalogs

### DIFF
--- a/languages/working-with-toc-en_US.po
+++ b/languages/working-with-toc-en_US.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Working with TOC 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc/\n"
-"POT-Creation-Date: 2024-05-30 00:00+0000\n"
-"PO-Revision-Date: 2024-05-30 00:00+0000\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc\n"
+"POT-Creation-Date: 2025-10-02T18:22:20+00:00\n"
+"PO-Revision-Date: 2025-10-02 18:30+0000\n"
 "Last-Translator: ChatGPT <chatgpt@example.com>\n"
 "Language-Team: English\n"
 "Language: en_US\n"
@@ -14,165 +14,248 @@ msgstr ""
 "X-Generator: ChatGPT\n"
 "X-Domain: working-with-toc\n"
 
-#: includes/admin/class-admin-page.php:67 includes/admin/class-admin-page.php:68 includes/admin/class-admin-page.php:121 includes/class-plugin.php:147 includes/class-settings.php:74
+#. Plugin Name of the plugin
+#: working-with-toc.php includes/admin/class-admin-page.php:73
+#: includes/admin/class-admin-page.php:90
+#: includes/admin/class-admin-page.php:91
+#: includes/admin/class-admin-page.php:146 includes/class-plugin.php:147
 msgid "Working with TOC"
 msgstr "Working with TOC"
 
-#: includes/admin/class-admin-page.php:75
+#. Plugin URI of the plugin
+#: working-with-toc.php
+msgid "https://wordpress.org/plugins/working-with-toc/"
+msgstr "https://wordpress.org/plugins/working-with-toc/"
+
+#. Description of the plugin
+#: working-with-toc.php
+msgid ""
+"Table of Contents plugin with structured data controls and Rank Math / Yoast "
+"SEO compatibility."
+msgstr ""
+"Table of Contents plugin with structured data controls and Rank Math / Yoast "
+"SEO compatibility."
+
+#. Author of the plugin
+#: working-with-toc.php
+msgid "Alfonso Vertucci - Working with Web"
+msgstr "Alfonso Vertucci - Working with Web"
+
+#. Author URI of the plugin
+#: working-with-toc.php
+msgid "https://workingwithweb.it/webagency"
+msgstr "https://workingwithweb.it/webagency"
+
+#: includes/admin/class-admin-page.php:126
 msgid "Activated"
 msgstr "Activated"
 
-#: includes/admin/class-admin-page.php:76
+#: includes/admin/class-admin-page.php:127
 msgid "Deactivated"
 msgstr "Deactivated"
 
-#: includes/admin/class-admin-page.php:122
+#: includes/admin/class-admin-page.php:147
 msgid "Manage structured data for posts, products, and pages."
 msgstr "Manage structured data for posts, products, and pages."
 
-#: includes/admin/class-admin-page.php:131
+#: includes/admin/class-admin-page.php:156
 msgid "Posts"
 msgstr "Posts"
 
-#: includes/admin/class-admin-page.php:132
+#: includes/admin/class-admin-page.php:157
 msgid "Enable the TOC and structured data for standard posts."
 msgstr "Enable the TOC and structured data for standard posts."
 
-#: includes/admin/class-admin-page.php:137
+#: includes/admin/class-admin-page.php:162
 msgid "Pages"
 msgstr "Pages"
 
-#: includes/admin/class-admin-page.php:138
+#: includes/admin/class-admin-page.php:163
 msgid "Enable the TOC for the site's static pages."
 msgstr "Enable the TOC for the site's static pages."
 
-#: includes/admin/class-admin-page.php:143
+#: includes/admin/class-admin-page.php:168
 msgid "Products"
 msgstr "Products"
 
-#: includes/admin/class-admin-page.php:144
+#: includes/admin/class-admin-page.php:169
 msgid "Integrate with WooCommerce for complete product pages."
 msgstr "Integrate with WooCommerce for complete product pages."
 
-#: includes/admin/class-admin-page.php:151 includes/admin/class-meta-box.php:499
+#: includes/admin/class-admin-page.php:176
+#: includes/admin/class-meta-box.php:506
 msgid "Title color"
 msgstr "Title color"
 
-#: includes/admin/class-admin-page.php:152 includes/admin/class-meta-box.php:501
+#: includes/admin/class-admin-page.php:177
+#: includes/admin/class-meta-box.php:508
 msgid "Title background"
 msgstr "Title background"
 
-#: includes/admin/class-admin-page.php:153 includes/admin/class-meta-box.php:503
+#: includes/admin/class-admin-page.php:178
+#: includes/admin/class-meta-box.php:510
 msgid "Container background"
 msgstr "Container background"
 
-#: includes/admin/class-admin-page.php:154 includes/admin/class-meta-box.php:505
+#: includes/admin/class-admin-page.php:179
+#: includes/admin/class-meta-box.php:512
 msgid "Text color"
 msgstr "Text color"
 
-#: includes/admin/class-admin-page.php:155 includes/admin/class-meta-box.php:507
+#: includes/admin/class-admin-page.php:180
+#: includes/admin/class-meta-box.php:514
 msgid "Link color"
 msgstr "Link color"
 
-#: includes/admin/class-admin-page.php:159 includes/admin/class-meta-box.php:139
+#: includes/admin/class-admin-page.php:184
+#: includes/admin/class-meta-box.php:139
 msgid "Left"
 msgstr "Left"
 
-#: includes/admin/class-admin-page.php:160 includes/admin/class-meta-box.php:140
+#: includes/admin/class-admin-page.php:185
+#: includes/admin/class-meta-box.php:140
 msgid "Center"
 msgstr "Center"
 
-#: includes/admin/class-admin-page.php:161 includes/admin/class-meta-box.php:141
+#: includes/admin/class-admin-page.php:186
+#: includes/admin/class-meta-box.php:141
 msgid "Right"
 msgstr "Right"
 
-#: includes/admin/class-admin-page.php:165 includes/admin/class-meta-box.php:145
+#: includes/admin/class-admin-page.php:190
+#: includes/admin/class-meta-box.php:145
 msgid "Top"
 msgstr "Top"
 
-#: includes/admin/class-admin-page.php:166 includes/admin/class-meta-box.php:146
+#: includes/admin/class-admin-page.php:191
+#: includes/admin/class-meta-box.php:146
 msgid "Bottom"
 msgstr "Bottom"
 
-#: includes/admin/class-admin-page.php:189 includes/admin/class-meta-box.php:45 includes/class-settings.php:75 includes/frontend/class-frontend.php:205 includes/structured-data/class-structured-data-manager.php:263
+#: includes/admin/class-admin-page.php:214 includes/admin/class-meta-box.php:45
+#: includes/class-settings.php:75 includes/frontend/class-frontend.php:201
+#: includes/structured-data/class-structured-data-manager.php:263
 msgid "Table of contents"
 msgstr "Table of contents"
 
-#: includes/admin/class-admin-page.php:196
+#: includes/admin/class-admin-page.php:221
 msgid "TOC structured data"
 msgstr "TOC structured data"
 
-#: includes/admin/class-admin-page.php:205
+#: includes/admin/class-admin-page.php:230
 msgid "Default style"
 msgstr "Default style"
 
-#: includes/admin/class-admin-page.php:206
-msgid "Set the title and base colors for the table of contents on this content type."
-msgstr "Set the title and base colors for the table of contents on this content type."
+#: includes/admin/class-admin-page.php:231
+msgid ""
+"Set the title and base colors for the table of contents on this content type."
+msgstr ""
+"Set the title and base colors for the table of contents on this content type."
 
-#: includes/admin/class-admin-page.php:208 includes/admin/class-meta-box.php:156
+#: includes/admin/class-admin-page.php:233
+#: includes/admin/class-meta-box.php:156
 msgid "TOC title"
 msgstr "TOC title"
 
-#: includes/admin/class-admin-page.php:224 includes/admin/class-meta-box.php:186
+#: includes/admin/class-admin-page.php:249
+#: includes/admin/class-meta-box.php:186
 msgid "Horizontal position"
 msgstr "Horizontal position"
 
-#: includes/admin/class-admin-page.php:232 includes/admin/class-meta-box.php:194
+#: includes/admin/class-admin-page.php:257
+#: includes/admin/class-meta-box.php:194
 msgid "Vertical position"
 msgstr "Vertical position"
 
-#: includes/admin/class-admin-page.php:263
-msgid "Save settings"
-msgstr "Save settings"
-
-#: includes/admin/class-admin-page.php:243
+#: includes/admin/class-admin-page.php:268
 msgid "Base structured data defaults"
 msgstr "Base structured data defaults"
 
-#: includes/admin/class-admin-page.php:244
-msgid "These values are used when the automatic headline, description, or image cannot be detected."
-msgstr "These values are used when the automatic headline, description, or image cannot be detected."
+#: includes/admin/class-admin-page.php:269
+msgid ""
+"These values are used when the automatic headline, description, or image "
+"cannot be detected."
+msgstr ""
+"These values are used when the automatic headline, description, or image "
+"cannot be detected."
 
-#: includes/admin/class-admin-page.php:246
+#: includes/admin/class-admin-page.php:271
 msgid "Fallback headline"
 msgstr "Fallback headline"
 
-#: includes/admin/class-admin-page.php:250
+#: includes/admin/class-admin-page.php:275
 msgid "Fallback description"
 msgstr "Fallback description"
 
-#: includes/admin/class-admin-page.php:254
+#: includes/admin/class-admin-page.php:279
 msgid "Fallback image URL"
 msgstr "Fallback image URL"
 
-#: includes/admin/class-admin-page.php:267
+#: includes/admin/class-admin-page.php:288
 msgid "Organization structured data"
 msgstr "Organization structured data"
 
-#: includes/admin/class-admin-page.php:268
-msgid "Customise the organisation details used for fallback structured data output."
-msgstr "Customise the organisation details used for fallback structured data output."
+#: includes/admin/class-admin-page.php:289
+msgid ""
+"Customise the organisation details used for fallback structured data output."
+msgstr ""
+"Customise the organisation details used for fallback structured data output."
 
-#: includes/admin/class-admin-page.php:271
+#: includes/admin/class-admin-page.php:292
 msgid "Organization name"
 msgstr "Organization name"
 
-#: includes/admin/class-admin-page.php:275
+#: includes/admin/class-admin-page.php:296
 msgid "Organization URL"
 msgstr "Organization URL"
 
-#: includes/admin/class-admin-page.php:279
+#: includes/admin/class-admin-page.php:300
 msgid "Logo URL"
 msgstr "Logo URL"
 
-#: includes/admin/class-admin-page.php:285
-msgid "Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events."
-msgstr "Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events."
+#: includes/admin/class-admin-page.php:307
+msgid "Save settings"
+msgstr "Save settings"
+
+#: includes/admin/class-admin-page.php:312
+msgid "Working with Web logo"
+msgstr "Working with Web logo"
+
+#: includes/admin/class-admin-page.php:321
+msgid "Version:"
+msgstr "Version:"
+
+#: includes/admin/class-admin-page.php:323
+msgid "Author:"
+msgstr "Author:"
+
+#: includes/admin/class-admin-page.php:332
+msgid "Plugin URI:"
+msgstr "Plugin URI:"
+
+#: includes/admin/class-admin-page.php:332
+msgid "View plugin page"
+msgstr "View plugin page"
+
+#: includes/admin/class-admin-page.php:334
+msgid "License:"
+msgstr "License:"
+
+#: includes/admin/class-admin-page.php:336
+msgid "Requires WordPress:"
+msgstr "Requires WordPress:"
+
+#: includes/admin/class-admin-page.php:339
+msgid "Requires PHP:"
+msgstr "Requires PHP:"
 
 #: includes/admin/class-meta-box.php:153
-msgid "Customize the table of contents for this entry. The plugin's global settings apply when fields are left unchanged."
-msgstr "Customize the table of contents for this entry. The plugin's global settings apply when fields are left unchanged."
+msgid ""
+"Customize the table of contents for this entry. The plugin's global settings "
+"apply when fields are left unchanged."
+msgstr ""
+"Customize the table of contents for this entry. The plugin's global settings "
+"apply when fields are left unchanged."
 
 #: includes/admin/class-meta-box.php:159 includes/admin/class-meta-box.php:174
 msgid "Reset"
@@ -191,8 +274,12 @@ msgid "Structured data overrides"
 msgstr "Structured data overrides"
 
 #: includes/admin/class-meta-box.php:206
-msgid "Update the fallback structured data values used when no SEO plugin provides a graph. Leave fields blank to use the automatic values."
-msgstr "Update the fallback structured data values used when no SEO plugin provides a graph. Leave fields blank to use the automatic values."
+msgid ""
+"Update the fallback structured data values used when no SEO plugin provides "
+"a graph. Leave fields blank to use the automatic values."
+msgstr ""
+"Update the fallback structured data values used when no SEO plugin provides "
+"a graph. Leave fields blank to use the automatic values."
 
 #: includes/admin/class-meta-box.php:208
 msgid "Headline"
@@ -211,14 +298,20 @@ msgid "Included headings"
 msgstr "Included headings"
 
 #: includes/admin/class-meta-box.php:237
-msgid "Deselect the headings you do not want to display in the table of contents."
-msgstr "Deselect the headings you do not want to display in the table of contents."
+msgid ""
+"Deselect the headings you do not want to display in the table of contents."
+msgstr ""
+"Deselect the headings you do not want to display in the table of contents."
 
 #: includes/admin/class-meta-box.php:239
-msgid "Add headings (H2-H6) to the content and save to generate the table of contents automatically."
-msgstr "Add headings (H2-H6) to the content and save to generate the table of contents automatically."
+msgid ""
+"Add headings (H2-H6) to the content and save to generate the table of "
+"contents automatically."
+msgstr ""
+"Add headings (H2-H6) to the content and save to generate the table of "
+"contents automatically."
 
-#: includes/admin/class-meta-box.php:509
+#: includes/admin/class-meta-box.php:516
 msgid "Color"
 msgstr "Color"
 
@@ -227,5 +320,10 @@ msgid "Toggle table of contents visibility"
 msgstr "Toggle table of contents visibility"
 
 #: includes/functions-dependencies.php:33
-msgid "Working with TOC requires the PHP DOM extension. Please enable the DOM extension to use the plugin."
-msgstr "Working with TOC requires the PHP DOM extension. Please enable the DOM extension to use the plugin."
+msgid ""
+"Working with TOC requires the PHP DOM extension. Please enable the DOM "
+"extension to use the plugin."
+msgstr ""
+"Working with TOC requires the PHP DOM extension. Please enable the DOM "
+"extension to use the plugin."
+

--- a/languages/working-with-toc-it_IT.po
+++ b/languages/working-with-toc-it_IT.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Working with TOC 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc/\n"
-"POT-Creation-Date: 2024-05-30 00:00+0000\n"
-"PO-Revision-Date: 2024-05-30 00:00+0000\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc\n"
+"POT-Creation-Date: 2025-10-02T18:22:20+00:00\n"
+"PO-Revision-Date: 2025-10-02 18:30+0000\n"
 "Last-Translator: ChatGPT <chatgpt@example.com>\n"
 "Language-Team: Italian\n"
 "Language: it_IT\n"
@@ -14,165 +14,249 @@ msgstr ""
 "X-Generator: ChatGPT\n"
 "X-Domain: working-with-toc\n"
 
-#: includes/admin/class-admin-page.php:67 includes/admin/class-admin-page.php:68 includes/admin/class-admin-page.php:121 includes/class-plugin.php:147 includes/class-settings.php:74
+#. Plugin Name of the plugin
+#: working-with-toc.php includes/admin/class-admin-page.php:73
+#: includes/admin/class-admin-page.php:90
+#: includes/admin/class-admin-page.php:91
+#: includes/admin/class-admin-page.php:146 includes/class-plugin.php:147
 msgid "Working with TOC"
 msgstr "Working with TOC"
 
-#: includes/admin/class-admin-page.php:75
+#. Plugin URI of the plugin
+#: working-with-toc.php
+msgid "https://wordpress.org/plugins/working-with-toc/"
+msgstr "https://wordpress.org/plugins/working-with-toc/"
+
+#. Description of the plugin
+#: working-with-toc.php
+msgid ""
+"Table of Contents plugin with structured data controls and Rank Math / Yoast "
+"SEO compatibility."
+msgstr ""
+"Plugin per indice dei contenuti con controlli per i dati strutturati e "
+"compatibilità con Rank Math / Yoast SEO."
+
+#. Author of the plugin
+#: working-with-toc.php
+msgid "Alfonso Vertucci - Working with Web"
+msgstr "Alfonso Vertucci - Working with Web"
+
+#. Author URI of the plugin
+#: working-with-toc.php
+msgid "https://workingwithweb.it/webagency"
+msgstr "https://workingwithweb.it/webagency"
+
+#: includes/admin/class-admin-page.php:126
 msgid "Activated"
 msgstr "Attivato"
 
-#: includes/admin/class-admin-page.php:76
+#: includes/admin/class-admin-page.php:127
 msgid "Deactivated"
 msgstr "Disattivato"
 
-#: includes/admin/class-admin-page.php:122
+#: includes/admin/class-admin-page.php:147
 msgid "Manage structured data for posts, products, and pages."
 msgstr "Gestisci i dati strutturati per articoli, prodotti e pagine."
 
-#: includes/admin/class-admin-page.php:131
+#: includes/admin/class-admin-page.php:156
 msgid "Posts"
 msgstr "Articoli"
 
-#: includes/admin/class-admin-page.php:132
+#: includes/admin/class-admin-page.php:157
 msgid "Enable the TOC and structured data for standard posts."
 msgstr "Abilita l'indice e i dati strutturati per gli articoli standard."
 
-#: includes/admin/class-admin-page.php:137
+#: includes/admin/class-admin-page.php:162
 msgid "Pages"
 msgstr "Pagine"
 
-#: includes/admin/class-admin-page.php:138
+#: includes/admin/class-admin-page.php:163
 msgid "Enable the TOC for the site's static pages."
 msgstr "Attiva l'indice per le pagine statiche del sito."
 
-#: includes/admin/class-admin-page.php:143
+#: includes/admin/class-admin-page.php:168
 msgid "Products"
 msgstr "Prodotti"
 
-#: includes/admin/class-admin-page.php:144
+#: includes/admin/class-admin-page.php:169
 msgid "Integrate with WooCommerce for complete product pages."
 msgstr "Integra con WooCommerce per schede prodotto complete."
 
-#: includes/admin/class-admin-page.php:151 includes/admin/class-meta-box.php:499
+#: includes/admin/class-admin-page.php:176
+#: includes/admin/class-meta-box.php:506
 msgid "Title color"
 msgstr "Colore del titolo"
 
-#: includes/admin/class-admin-page.php:152 includes/admin/class-meta-box.php:501
+#: includes/admin/class-admin-page.php:177
+#: includes/admin/class-meta-box.php:508
 msgid "Title background"
 msgstr "Sfondo del titolo"
 
-#: includes/admin/class-admin-page.php:153 includes/admin/class-meta-box.php:503
+#: includes/admin/class-admin-page.php:178
+#: includes/admin/class-meta-box.php:510
 msgid "Container background"
 msgstr "Sfondo del contenitore"
 
-#: includes/admin/class-admin-page.php:154 includes/admin/class-meta-box.php:505
+#: includes/admin/class-admin-page.php:179
+#: includes/admin/class-meta-box.php:512
 msgid "Text color"
 msgstr "Colore del testo"
 
-#: includes/admin/class-admin-page.php:155 includes/admin/class-meta-box.php:507
+#: includes/admin/class-admin-page.php:180
+#: includes/admin/class-meta-box.php:514
 msgid "Link color"
 msgstr "Colore dei link"
 
-#: includes/admin/class-admin-page.php:159 includes/admin/class-meta-box.php:139
+#: includes/admin/class-admin-page.php:184
+#: includes/admin/class-meta-box.php:139
 msgid "Left"
 msgstr "Sinistra"
 
-#: includes/admin/class-admin-page.php:160 includes/admin/class-meta-box.php:140
+#: includes/admin/class-admin-page.php:185
+#: includes/admin/class-meta-box.php:140
 msgid "Center"
 msgstr "Centro"
 
-#: includes/admin/class-admin-page.php:161 includes/admin/class-meta-box.php:141
+#: includes/admin/class-admin-page.php:186
+#: includes/admin/class-meta-box.php:141
 msgid "Right"
 msgstr "Destra"
 
-#: includes/admin/class-admin-page.php:165 includes/admin/class-meta-box.php:145
+#: includes/admin/class-admin-page.php:190
+#: includes/admin/class-meta-box.php:145
 msgid "Top"
 msgstr "In alto"
 
-#: includes/admin/class-admin-page.php:166 includes/admin/class-meta-box.php:146
+#: includes/admin/class-admin-page.php:191
+#: includes/admin/class-meta-box.php:146
 msgid "Bottom"
 msgstr "In basso"
 
-#: includes/admin/class-admin-page.php:189 includes/admin/class-meta-box.php:45 includes/class-settings.php:75 includes/frontend/class-frontend.php:205 includes/structured-data/class-structured-data-manager.php:263
+#: includes/admin/class-admin-page.php:214 includes/admin/class-meta-box.php:45
+#: includes/class-settings.php:75 includes/frontend/class-frontend.php:201
+#: includes/structured-data/class-structured-data-manager.php:263
 msgid "Table of contents"
 msgstr "Indice dei contenuti"
 
-#: includes/admin/class-admin-page.php:196
+#: includes/admin/class-admin-page.php:221
 msgid "TOC structured data"
 msgstr "Dati strutturati dell'indice"
 
-#: includes/admin/class-admin-page.php:205
+#: includes/admin/class-admin-page.php:230
 msgid "Default style"
 msgstr "Stile predefinito"
 
-#: includes/admin/class-admin-page.php:206
-msgid "Set the title and base colors for the table of contents on this content type."
-msgstr "Imposta titolo e colori di base per l'indice in questo tipo di contenuto."
+#: includes/admin/class-admin-page.php:231
+msgid ""
+"Set the title and base colors for the table of contents on this content type."
+msgstr ""
+"Imposta titolo e colori di base per l'indice in questo tipo di contenuto."
 
-#: includes/admin/class-admin-page.php:208 includes/admin/class-meta-box.php:156
+#: includes/admin/class-admin-page.php:233
+#: includes/admin/class-meta-box.php:156
 msgid "TOC title"
 msgstr "Titolo dell'indice"
 
-#: includes/admin/class-admin-page.php:224 includes/admin/class-meta-box.php:186
+#: includes/admin/class-admin-page.php:249
+#: includes/admin/class-meta-box.php:186
 msgid "Horizontal position"
 msgstr "Posizione orizzontale"
 
-#: includes/admin/class-admin-page.php:232 includes/admin/class-meta-box.php:194
+#: includes/admin/class-admin-page.php:257
+#: includes/admin/class-meta-box.php:194
 msgid "Vertical position"
 msgstr "Posizione verticale"
 
-#: includes/admin/class-admin-page.php:263
-msgid "Save settings"
-msgstr "Salva impostazioni"
-
-#: includes/admin/class-admin-page.php:243
+#: includes/admin/class-admin-page.php:268
 msgid "Base structured data defaults"
 msgstr "Valori predefiniti dei dati strutturati"
 
-#: includes/admin/class-admin-page.php:244
-msgid "These values are used when the automatic headline, description, or image cannot be detected."
-msgstr "Questi valori vengono usati quando non è possibile rilevare automaticamente titolo, descrizione o immagine."
+#: includes/admin/class-admin-page.php:269
+msgid ""
+"These values are used when the automatic headline, description, or image "
+"cannot be detected."
+msgstr ""
+"Questi valori vengono usati quando non è possibile rilevare automaticamente "
+"titolo, descrizione o immagine."
 
-#: includes/admin/class-admin-page.php:246
+#: includes/admin/class-admin-page.php:271
 msgid "Fallback headline"
 msgstr "Titolo di riserva"
 
-#: includes/admin/class-admin-page.php:250
+#: includes/admin/class-admin-page.php:275
 msgid "Fallback description"
 msgstr "Descrizione di riserva"
 
-#: includes/admin/class-admin-page.php:254
+#: includes/admin/class-admin-page.php:279
 msgid "Fallback image URL"
 msgstr "URL immagine di riserva"
 
-#: includes/admin/class-admin-page.php:267
+#: includes/admin/class-admin-page.php:288
 msgid "Organization structured data"
 msgstr "Dati strutturati dell'organizzazione"
 
-#: includes/admin/class-admin-page.php:268
-msgid "Customise the organisation details used for fallback structured data output."
-msgstr "Personalizza i dati dell'organizzazione utilizzati come riserva nei dati strutturati."
+#: includes/admin/class-admin-page.php:289
+msgid ""
+"Customise the organisation details used for fallback structured data output."
+msgstr ""
+"Personalizza i dati dell'organizzazione utilizzati come riserva nei dati "
+"strutturati."
 
-#: includes/admin/class-admin-page.php:271
+#: includes/admin/class-admin-page.php:292
 msgid "Organization name"
 msgstr "Nome dell'organizzazione"
 
-#: includes/admin/class-admin-page.php:275
+#: includes/admin/class-admin-page.php:296
 msgid "Organization URL"
 msgstr "URL dell'organizzazione"
 
-#: includes/admin/class-admin-page.php:279
+#: includes/admin/class-admin-page.php:300
 msgid "Logo URL"
 msgstr "URL del logo"
 
-#: includes/admin/class-admin-page.php:285
-msgid "Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events."
-msgstr "Compatibile con Rank Math e Yoast SEO. Attiva la modalità di debug di WordPress per registrare gli eventi del plugin."
+#: includes/admin/class-admin-page.php:307
+msgid "Save settings"
+msgstr "Salva impostazioni"
+
+#: includes/admin/class-admin-page.php:312
+msgid "Working with Web logo"
+msgstr "Logo Working with Web"
+
+#: includes/admin/class-admin-page.php:321
+msgid "Version:"
+msgstr "Versione:"
+
+#: includes/admin/class-admin-page.php:323
+msgid "Author:"
+msgstr "Autore:"
+
+#: includes/admin/class-admin-page.php:332
+msgid "Plugin URI:"
+msgstr "URL del plugin:"
+
+#: includes/admin/class-admin-page.php:332
+msgid "View plugin page"
+msgstr "Visualizza pagina del plugin"
+
+#: includes/admin/class-admin-page.php:334
+msgid "License:"
+msgstr "Licenza:"
+
+#: includes/admin/class-admin-page.php:336
+msgid "Requires WordPress:"
+msgstr "Richiede WordPress:"
+
+#: includes/admin/class-admin-page.php:339
+msgid "Requires PHP:"
+msgstr "Richiede PHP:"
 
 #: includes/admin/class-meta-box.php:153
-msgid "Customize the table of contents for this entry. The plugin's global settings apply when fields are left unchanged."
-msgstr "Personalizza l'indice dei contenuti per questo elemento. Le impostazioni globali del plugin si applicano quando i campi restano invariati."
+msgid ""
+"Customize the table of contents for this entry. The plugin's global settings "
+"apply when fields are left unchanged."
+msgstr ""
+"Personalizza l'indice dei contenuti per questo elemento. Le impostazioni "
+"globali del plugin si applicano quando i campi restano invariati."
 
 #: includes/admin/class-meta-box.php:159 includes/admin/class-meta-box.php:174
 msgid "Reset"
@@ -191,8 +275,12 @@ msgid "Structured data overrides"
 msgstr "Dati strutturati personalizzati"
 
 #: includes/admin/class-meta-box.php:206
-msgid "Update the fallback structured data values used when no SEO plugin provides a graph. Leave fields blank to use the automatic values."
-msgstr "Aggiorna i valori di riserva dei dati strutturati usati quando nessun plugin SEO fornisce un grafo. Lascia i campi vuoti per usare i valori automatici."
+msgid ""
+"Update the fallback structured data values used when no SEO plugin provides "
+"a graph. Leave fields blank to use the automatic values."
+msgstr ""
+"Aggiorna i valori di riserva dei dati strutturati usati quando nessun plugin "
+"SEO fornisce un grafo. Lascia i campi vuoti per usare i valori automatici."
 
 #: includes/admin/class-meta-box.php:208
 msgid "Headline"
@@ -211,14 +299,19 @@ msgid "Included headings"
 msgstr "Titoli inclusi"
 
 #: includes/admin/class-meta-box.php:237
-msgid "Deselect the headings you do not want to display in the table of contents."
+msgid ""
+"Deselect the headings you do not want to display in the table of contents."
 msgstr "Deseleziona i titoli che non vuoi mostrare nell'indice dei contenuti."
 
 #: includes/admin/class-meta-box.php:239
-msgid "Add headings (H2-H6) to the content and save to generate the table of contents automatically."
-msgstr "Aggiungi intestazioni (H2-H6) al contenuto e salva per generare automaticamente l'indice dei contenuti."
+msgid ""
+"Add headings (H2-H6) to the content and save to generate the table of "
+"contents automatically."
+msgstr ""
+"Aggiungi intestazioni (H2-H6) al contenuto e salva per generare "
+"automaticamente l'indice dei contenuti."
 
-#: includes/admin/class-meta-box.php:509
+#: includes/admin/class-meta-box.php:516
 msgid "Color"
 msgstr "Colore"
 
@@ -227,5 +320,10 @@ msgid "Toggle table of contents visibility"
 msgstr "Attiva o disattiva la visibilità dell'indice dei contenuti"
 
 #: includes/functions-dependencies.php:33
-msgid "Working with TOC requires the PHP DOM extension. Please enable the DOM extension to use the plugin."
-msgstr "Working with TOC richiede l'estensione PHP DOM. Abilita l'estensione DOM per utilizzare il plugin."
+msgid ""
+"Working with TOC requires the PHP DOM extension. Please enable the DOM "
+"extension to use the plugin."
+msgstr ""
+"Working with TOC richiede l'estensione PHP DOM. Abilita l'estensione DOM per "
+"utilizzare il plugin."
+

--- a/languages/working-with-toc.pot
+++ b/languages/working-with-toc.pot
@@ -1,175 +1,252 @@
+# Copyright (C) 2025 Alfonso Vertucci - Working with Web
+# This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
 "Project-Id-Version: Working with TOC 1.0.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc/\n"
-"POT-Creation-Date: 2024-05-30 00:00+0000\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/working-with-toc\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: ChatGPT\n"
+"POT-Creation-Date: 2025-10-02T18:22:20+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: working-with-toc\n"
 
-#: includes/admin/class-admin-page.php:67 includes/admin/class-admin-page.php:68 includes/admin/class-admin-page.php:121 includes/class-plugin.php:147 includes/class-settings.php:74
+#. Plugin Name of the plugin
+#: working-with-toc.php
+#: includes/admin/class-admin-page.php:73
+#: includes/admin/class-admin-page.php:90
+#: includes/admin/class-admin-page.php:91
+#: includes/admin/class-admin-page.php:146
+#: includes/class-plugin.php:147
 msgid "Working with TOC"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:75
+#. Plugin URI of the plugin
+#: working-with-toc.php
+msgid "https://wordpress.org/plugins/working-with-toc/"
+msgstr ""
+
+#. Description of the plugin
+#: working-with-toc.php
+msgid "Table of Contents plugin with structured data controls and Rank Math / Yoast SEO compatibility."
+msgstr ""
+
+#. Author of the plugin
+#: working-with-toc.php
+msgid "Alfonso Vertucci - Working with Web"
+msgstr ""
+
+#. Author URI of the plugin
+#: working-with-toc.php
+msgid "https://workingwithweb.it/webagency"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:126
 msgid "Activated"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:76
+#: includes/admin/class-admin-page.php:127
 msgid "Deactivated"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:122
+#: includes/admin/class-admin-page.php:147
 msgid "Manage structured data for posts, products, and pages."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:131
+#: includes/admin/class-admin-page.php:156
 msgid "Posts"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:132
+#: includes/admin/class-admin-page.php:157
 msgid "Enable the TOC and structured data for standard posts."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:137
+#: includes/admin/class-admin-page.php:162
 msgid "Pages"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:138
+#: includes/admin/class-admin-page.php:163
 msgid "Enable the TOC for the site's static pages."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:143
+#: includes/admin/class-admin-page.php:168
 msgid "Products"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:144
+#: includes/admin/class-admin-page.php:169
 msgid "Integrate with WooCommerce for complete product pages."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:151 includes/admin/class-meta-box.php:499
+#: includes/admin/class-admin-page.php:176
+#: includes/admin/class-meta-box.php:506
 msgid "Title color"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:152 includes/admin/class-meta-box.php:501
+#: includes/admin/class-admin-page.php:177
+#: includes/admin/class-meta-box.php:508
 msgid "Title background"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:153 includes/admin/class-meta-box.php:503
+#: includes/admin/class-admin-page.php:178
+#: includes/admin/class-meta-box.php:510
 msgid "Container background"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:154 includes/admin/class-meta-box.php:505
+#: includes/admin/class-admin-page.php:179
+#: includes/admin/class-meta-box.php:512
 msgid "Text color"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:155 includes/admin/class-meta-box.php:507
+#: includes/admin/class-admin-page.php:180
+#: includes/admin/class-meta-box.php:514
 msgid "Link color"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:159 includes/admin/class-meta-box.php:139
+#: includes/admin/class-admin-page.php:184
+#: includes/admin/class-meta-box.php:139
 msgid "Left"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:160 includes/admin/class-meta-box.php:140
+#: includes/admin/class-admin-page.php:185
+#: includes/admin/class-meta-box.php:140
 msgid "Center"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:161 includes/admin/class-meta-box.php:141
+#: includes/admin/class-admin-page.php:186
+#: includes/admin/class-meta-box.php:141
 msgid "Right"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:165 includes/admin/class-meta-box.php:145
+#: includes/admin/class-admin-page.php:190
+#: includes/admin/class-meta-box.php:145
 msgid "Top"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:166 includes/admin/class-meta-box.php:146
+#: includes/admin/class-admin-page.php:191
+#: includes/admin/class-meta-box.php:146
 msgid "Bottom"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:189 includes/admin/class-meta-box.php:45 includes/class-settings.php:75 includes/frontend/class-frontend.php:205 includes/structured-data/class-structured-data-manager.php:263
+#: includes/admin/class-admin-page.php:214
+#: includes/admin/class-meta-box.php:45
+#: includes/class-settings.php:75
+#: includes/frontend/class-frontend.php:201
+#: includes/structured-data/class-structured-data-manager.php:263
 msgid "Table of contents"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:196
+#: includes/admin/class-admin-page.php:221
 msgid "TOC structured data"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:205
+#: includes/admin/class-admin-page.php:230
 msgid "Default style"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:206
+#: includes/admin/class-admin-page.php:231
 msgid "Set the title and base colors for the table of contents on this content type."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:208 includes/admin/class-meta-box.php:156
+#: includes/admin/class-admin-page.php:233
+#: includes/admin/class-meta-box.php:156
 msgid "TOC title"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:224 includes/admin/class-meta-box.php:186
+#: includes/admin/class-admin-page.php:249
+#: includes/admin/class-meta-box.php:186
 msgid "Horizontal position"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:232 includes/admin/class-meta-box.php:194
+#: includes/admin/class-admin-page.php:257
+#: includes/admin/class-meta-box.php:194
 msgid "Vertical position"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:263
-msgid "Save settings"
-msgstr ""
-
-#: includes/admin/class-admin-page.php:243
+#: includes/admin/class-admin-page.php:268
 msgid "Base structured data defaults"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:244
+#: includes/admin/class-admin-page.php:269
 msgid "These values are used when the automatic headline, description, or image cannot be detected."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:246
+#: includes/admin/class-admin-page.php:271
 msgid "Fallback headline"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:250
+#: includes/admin/class-admin-page.php:275
 msgid "Fallback description"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:254
+#: includes/admin/class-admin-page.php:279
 msgid "Fallback image URL"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:267
+#: includes/admin/class-admin-page.php:288
 msgid "Organization structured data"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:268
+#: includes/admin/class-admin-page.php:289
 msgid "Customise the organisation details used for fallback structured data output."
 msgstr ""
 
-#: includes/admin/class-admin-page.php:271
+#: includes/admin/class-admin-page.php:292
 msgid "Organization name"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:275
+#: includes/admin/class-admin-page.php:296
 msgid "Organization URL"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:279
+#: includes/admin/class-admin-page.php:300
 msgid "Logo URL"
 msgstr ""
 
-#: includes/admin/class-admin-page.php:285
-msgid "Compatible with Rank Math and Yoast SEO. Enable WordPress debug mode to log plugin events."
+#: includes/admin/class-admin-page.php:307
+msgid "Save settings"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:312
+msgid "Working with Web logo"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:321
+msgid "Version:"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:323
+msgid "Author:"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:332
+msgid "Plugin URI:"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:332
+msgid "View plugin page"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:334
+msgid "License:"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:336
+msgid "Requires WordPress:"
+msgstr ""
+
+#: includes/admin/class-admin-page.php:339
+msgid "Requires PHP:"
 msgstr ""
 
 #: includes/admin/class-meta-box.php:153
 msgid "Customize the table of contents for this entry. The plugin's global settings apply when fields are left unchanged."
 msgstr ""
 
-#: includes/admin/class-meta-box.php:159 includes/admin/class-meta-box.php:174
+#: includes/admin/class-meta-box.php:159
+#: includes/admin/class-meta-box.php:174
 msgid "Reset"
 msgstr ""
 
@@ -213,7 +290,7 @@ msgstr ""
 msgid "Add headings (H2-H6) to the content and save to generate the table of contents automatically."
 msgstr ""
 
-#: includes/admin/class-meta-box.php:509
+#: includes/admin/class-meta-box.php:516
 msgid "Color"
 msgstr ""
 


### PR DESCRIPTION
## Summary
- regenerate `languages/working-with-toc.pot` with WP-CLI to capture the latest plugin strings and discard removed entries
- sync the `en_US` and `it_IT` PO catalogs with the refreshed template, filling in translations for the new interface strings and removing obsolete ones

## Testing
- msgfmt --check --output-file=/dev/null languages/working-with-toc-en_US.po
- msgfmt --check --output-file=/dev/null languages/working-with-toc-it_IT.po

------
https://chatgpt.com/codex/tasks/task_e_68dec2ba01208333819415f3f3708dd7