### PR TITLE
Adjust admin menu icon for clarity

### DIFF
--- a/assets/images/menu-icon.svg
+++ b/assets/images/menu-icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+  <defs>
+    <linearGradient id="wwtMenuGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5d5fef" />
+      <stop offset="100%" stop-color="#7f53ac" />
+    </linearGradient>
+  </defs>
+  <rect width="24" height="24" rx="6" fill="#eef1ff" />
+  <path d="M6 6.5l2.1 9c.1.4.5.7.9.7h.1c.4 0 .8-.3.9-.7l1.4-5 1.4 5c.1.4.5.7.9.7h.1c.4 0 .8-.3.9-.7l2.1-9h-1.9l-1.2 5.5-1.5-5.5h-1.5l-1.5 5.5L7.9 6.5H6z" fill="url(#wwtMenuGradient)" />
+</svg>

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -92,7 +92,7 @@ class Admin_Page {
             $this->capability,
             'working-with-toc',
             array( $this, 'render_page' ),
-            WWT_TOC_PLUGIN_URL . 'assets/images/www-logo.png'
+            WWT_TOC_PLUGIN_URL . 'assets/images/menu-icon.svg'
         );
     }
 


### PR DESCRIPTION
## Summary
- replace the admin menu icon reference with a purpose-built SVG sized for the WordPress sidebar
- add the new gradient SVG icon asset so the plugin menu renders cleanly at 20px

## Testing
- php -l includes/admin/class-admin-page.php

------
https://chatgpt.com/codex/tasks/task_e_68dedbc458bc8333a0a07791f28373e8