### PR TITLE
Ensure TOC color defaults apply consistently

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,9 +1,9 @@
 .wwt-toc-container {
-    --wwt-toc-bg: #0f172a;
-    --wwt-toc-title-bg: #1e293b;
-    --wwt-toc-title-color: #f8fafc;
-    --wwt-toc-text: #e2e8f0;
-    --wwt-toc-link: #38bdf8;
+    --wwt-toc-bg: #ffffff;
+    --wwt-toc-title-bg: #1f2937;
+    --wwt-toc-title-color: #ffffff;
+    --wwt-toc-text: #111827;
+    --wwt-toc-link: #2563eb;
     --wwt-toc-translate-x: -50%;
     --wwt-toc-translate-y: 0;
     position: fixed;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -73,11 +73,11 @@ class Settings {
 
         $style_defaults = array(
             'title'                  => __( 'Table of contents', 'working-with-toc' ),
-            'title_color'            => '#f8fafc',
-            'title_background_color' => '#1e293b',
-            'background_color'       => '#0f172a',
-            'link_color'             => '#38bdf8',
-            'text_color'             => '#e2e8f0',
+            'title_color'            => '#ffffff',
+            'title_background_color' => '#1f2937',
+            'background_color'       => '#ffffff',
+            'link_color'             => '#2563eb',
+            'text_color'             => '#111827',
         );
 
         $alignment_defaults = array(
@@ -264,15 +264,43 @@ class Settings {
         $prefix   = $this->get_style_prefix( $post_type );
 
         $preferences = array();
+        $schema      = $this->get_option_schema();
 
         foreach ( $this->get_style_fields() as $field ) {
-            $key                   = $prefix . '_' . $field;
-            $preferences[ $field ] = $settings[ $key ] ?? '';
+            $key     = $prefix . '_' . $field;
+            $config  = $schema[ $key ] ?? array();
+            $default = isset( $config['default'] ) ? (string) $config['default'] : '';
+            $value   = $settings[ $key ] ?? null;
+
+            if ( 'title' === $field ) {
+                $preferences[ $field ] = ( is_string( $value ) && '' !== $value )
+                    ? sanitize_text_field( $value )
+                    : $default;
+                continue;
+            }
+
+            $preferences[ $field ] = $this->sanitize_color_value( $value, $default );
         }
 
         foreach ( $this->get_layout_fields() as $field ) {
-            $key                   = $prefix . '_' . $field;
-            $preferences[ $field ] = $settings[ $key ] ?? '';
+            $key     = $prefix . '_' . $field;
+            $config  = $schema[ $key ] ?? array();
+            $default = isset( $config['default'] ) ? (string) $config['default'] : '';
+            $value   = $settings[ $key ] ?? null;
+
+            if ( 'horizontal_alignment' === $field ) {
+                $preferences[ $field ] = $this->sanitize_horizontal_alignment( $value, $default ?: 'right' );
+                continue;
+            }
+
+            if ( 'vertical_alignment' === $field ) {
+                $preferences[ $field ] = $this->sanitize_vertical_alignment( $value, $default ?: 'bottom' );
+                continue;
+            }
+
+            $preferences[ $field ] = ( is_string( $value ) && '' !== $value )
+                ? sanitize_text_field( $value )
+                : $default;
         }
 
         $preferences['excluded_headings'] = array();


### PR DESCRIPTION
## Summary
- set higher-contrast default colors for the floating table of contents
- ensure post type defaults sanitise and fall back to the configured palette when article-level colours are missing

## Testing
- php -l includes/class-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68dedf2ffc988333ac97e8eec383ef82