### PR TITLE
Remove redundant Product schema TOC linkage

### DIFF
--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -493,8 +493,6 @@ class Structured_Data_Manager {
             '@id'              => $product_id,
             'name'             => wp_strip_all_tags( get_the_title( $post ) ),
             'mainEntityOfPage' => array( '@id' => $webpage_id ),
-            'isPartOf'         => array( '@id' => $website_id ),
-            'hasPart'          => array( array( '@id' => $item_list_id ) ),
         );
 
         if ( '' !== $values['description'] ) {


### PR DESCRIPTION
## Summary
- remove the `isPartOf` and `hasPart` properties from the Product node so the TOC ItemList is only linked from the WebPage schema
- ensure the WebPage schema retains its `hasPart` reference to the TOC ItemList for discoverability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68defd41c8988333a44ebed88a35f8f1