### PR TITLE
Ensure product structured data links ItemList

### DIFF
--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -495,6 +495,30 @@ class Structured_Data_Manager {
             'mainEntityOfPage' => array( '@id' => $webpage_id ),
         );
 
+        $has_part_entry = array( '@id' => $item_list_id );
+
+        if ( isset( $product_node['hasPart'] ) && is_array( $product_node['hasPart'] ) ) {
+            $has_part = $product_node['hasPart'];
+        } elseif ( isset( $product_node['hasPart'] ) ) {
+            $has_part = array( $product_node['hasPart'] );
+        } else {
+            $has_part = array();
+        }
+
+        $already_linked = false;
+        foreach ( $has_part as $part ) {
+            if ( is_array( $part ) && isset( $part['@id'] ) && $part['@id'] === $item_list_id ) {
+                $already_linked = true;
+                break;
+            }
+        }
+
+        if ( ! $already_linked ) {
+            $has_part[] = $has_part_entry;
+        }
+
+        $product_node['hasPart'] = $has_part;
+
         if ( '' !== $values['description'] ) {
             $product_node['description'] = $values['description'];
         }


### PR DESCRIPTION
## Summary
- ensure the product structured data node links to the generated TOC ItemList
- prevent duplicate hasPart entries when other integrations add their own references

## Testing
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68deffd3a2188333a1b550cb0d7e47fd