### PR TITLE
Update FAQ parser attributes to new data-faq contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ This makes the **Working with TOC** page available to any user with the `edit_ot
 
 The TOC appears in an accordion anchored to the bottom edge of the viewport. Visitors can open or collapse it instantly; when expanded, the content scrolls inside a slide-up panel with dynamic highlighting powered by `IntersectionObserver`.
 
+### FAQ data attributes
+
+When FAQ mode is enabled for specific headings, the parser annotates the matched elements so JavaScript and CSS can easily target them. Headings receive the `wwt-faq-question` class along with `data-faq="question"`, while the first matching answer container gains the `wwt-faq-answer` class and `data-faq-answer="true"`. These attributes replace the legacy `data-wwt-faq` markers and are applied directly by `Heading_Parser::parse()` so templates and structured data builders can rely on a consistent contract.
+
 ## SEO Compatibility
 
 - **Rank Math** – the plugin registers itself among supported TOCs, preventing the “No TOC plugin installed” warning.

--- a/includes/class-heading-parser.php
+++ b/includes/class-heading-parser.php
@@ -117,17 +117,16 @@ class Heading_Parser {
 
                 if ( $mark_faq && isset( $faq_ids[ $id ] ) ) {
                     self::add_class( $node, 'wwt-faq-question' );
-                    $node->setAttribute( 'data-wwt-faq', 'question' );
+                    $node->removeAttribute( 'data-wwt-faq' );
+                    $node->setAttribute( 'data-faq', 'question' );
 
                     if ( $mark_faq_answers && $faq_data['answer_node'] instanceof DOMElement ) {
                         $answer_node = $faq_data['answer_node'];
 
                         if ( 'body' !== strtolower( $answer_node->nodeName ) ) {
                             self::add_class( $answer_node, 'wwt-faq-answer' );
-
-                            if ( '' === $answer_node->getAttribute( 'data-wwt-faq' ) ) {
-                                $answer_node->setAttribute( 'data-wwt-faq', 'answer' );
-                            }
+                            $answer_node->removeAttribute( 'data-wwt-faq' );
+                            $answer_node->setAttribute( 'data-faq-answer', 'true' );
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- update the heading parser to emit the new `data-faq` and `data-faq-answer` attributes when marking FAQ content
- remove usage of the legacy `data-wwt-faq` attribute while keeping existing FAQ classes in place
- document the refreshed FAQ markup contract in the README for easier reference

## Testing
- php -l includes/class-heading-parser.php

------
https://chatgpt.com/codex/tasks/task_e_68df140f4ea8833396ef8161236b36a8