### PR TITLE
Provide full FAQ answers in structured data

### DIFF
--- a/includes/admin/class-meta-box.php
+++ b/includes/admin/class-meta-box.php
@@ -403,7 +403,7 @@ class Meta_Box {
      *
      * @param WP_Post $post Post object.
      *
-     * @return array<int,array{title:string,id:string,level:int,faq_excerpt?:string}>
+     * @return array<int,array{title:string,id:string,level:int,faq_excerpt?:string,faq_answer?:string}>
      */
     protected function get_headings( WP_Post $post ): array {
         if ( '' === $post->post_content ) {

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -280,7 +280,7 @@ class Frontend {
     /**
      * Filter headings according to the excluded list.
      *
-     * @param array<int,array{title:string,id:string,level:int,faq_excerpt?:string}> $headings Headings list.
+     * @param array<int,array{title:string,id:string,level:int,faq_excerpt?:string,faq_answer?:string}> $headings Headings list.
      * @param array<int,string>                                  $excluded IDs to exclude.
      *
      * @return array<int,array{title:string,id:string,level:int}>

--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -502,7 +502,7 @@ class Structured_Data_Manager {
      * @param WP_Post             $post        Post object.
      * @param array<string,mixed> $preferences Style preferences for the post.
      *
-     * @return array{headings:array<int,array{title:string,url:string,id:string,faq_excerpt?:string}>,faq:array<int,array{question:string,answer:string,url:string,id:string}>}
+     * @return array{headings:array<int,array{title:string,url:string,id:string,faq_excerpt?:string,faq_answer?:string}>,faq:array<int,array{question:string,answer:string,url:string,id:string}>}
      */
     protected function collect_headings( WP_Post $post, array $preferences ): array {
         $callback = array( $this->frontend, 'inject_toc' );
@@ -561,13 +561,14 @@ class Structured_Data_Manager {
                 'url'         => $url,
                 'id'          => $heading['id'],
                 'faq_excerpt' => isset( $heading['faq_excerpt'] ) ? (string) $heading['faq_excerpt'] : '',
+                'faq_answer'  => isset( $heading['faq_answer'] ) ? (string) $heading['faq_answer'] : '',
             );
 
             $headings[] = $entry;
 
             if ( isset( $faq_map[ $heading['id'] ] ) ) {
                 $question = wp_strip_all_tags( $heading['title'] );
-                $answer   = isset( $entry['faq_excerpt'] ) ? (string) $entry['faq_excerpt'] : '';
+                $answer   = isset( $entry['faq_answer'] ) ? (string) $entry['faq_answer'] : '';
 
                 if ( '' !== $question && '' !== $answer ) {
                     $faq_entries[] = array(
@@ -595,7 +596,7 @@ class Structured_Data_Manager {
      * Build the ItemList node describing the TOC.
      *
      * @param WP_Post             $post         Post object.
-     * @param array<int,array{title:string,url:string,id?:string,faq_excerpt?:string}> $headings Heading data.
+     * @param array<int,array{title:string,url:string,id?:string,faq_excerpt?:string,faq_answer?:string}> $headings Heading data.
      * @param array<string,mixed> $preferences  Post-specific preferences.
      *
      * @return array<string,mixed>


### PR DESCRIPTION
## Summary
- extend the heading parser to capture full FAQ answers alongside the existing previews
- update admin and structured data consumers to understand the expanded heading shape
- feed full answer text into FAQ schema output while keeping previews for the editor UI

## Testing
- php -l includes/class-heading-parser.php
- php -l includes/structured-data/class-structured-data-manager.php
- php -l includes/admin/class-meta-box.php
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68df14ce35648333983a294281312066