### PR TITLE
Link product ItemList relationships in fallback graph

### DIFF
--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -842,6 +842,24 @@ class Structured_Data_Manager {
             $product_node = $this->build_product_node( $post, $values, $webpage_id, $image_id, $permalink );
 
             if ( ! empty( $product_node ) ) {
+                $product_id = is_string( $product_node['@id'] ?? null ) ? $product_node['@id'] : '';
+
+                if ( '' !== $product_id && '' !== $item_list_id ) {
+                    $has_part = $this->normalize_reference_list( $product_node['hasPart'] ?? array() );
+                    $has_part = $this->add_reference_if_missing( $has_part, $item_list_id );
+
+                    if ( ! empty( $has_part ) ) {
+                        $product_node['hasPart'] = $has_part;
+                    }
+
+                    $item_list_is_part_of = $this->normalize_reference_list( $item_list['isPartOf'] ?? array() );
+                    $item_list_is_part_of = $this->add_reference_if_missing( $item_list_is_part_of, $product_id );
+
+                    if ( ! empty( $item_list_is_part_of ) ) {
+                        $item_list['isPartOf'] = $item_list_is_part_of;
+                    }
+                }
+
                 $graph[] = $product_node;
             }
         } elseif ( 'WebPage' !== $article_type ) {


### PR DESCRIPTION
## Summary
- ensure fallback Product nodes reference the table of contents ItemList via hasPart
- update ItemList fallback data to point back to the product for consistent bidirectional links

## Testing
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68df192c434883338471a01b51080610