### PR TITLE
Add AMP-friendly static TOC fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The TOC appears in an accordion anchored to the bottom edge of the viewport. Vis
 
 When FAQ mode is enabled for specific headings, the parser annotates the matched elements so JavaScript and CSS can easily target them. Headings receive the `wwt-faq-question` class along with `data-faq="question"`, while the first matching answer container gains the `wwt-faq-answer` class and `data-faq-answer="true"`. These attributes replace the legacy `data-wwt-faq` markers and are applied directly by `Heading_Parser::parse()` so templates and structured data builders can rely on a consistent contract.
 
+### AMP compatibility
+
+The frontend now detects AMP requests (using `is_amp_endpoint()` or `amp_is_request()` when available) and renders an accessible, always-on TOC without relying on JavaScript listeners. In AMP mode the plugin skips loading `assets/js/frontend.js` and swaps the floating container for a `<details>`-based layout that keeps the toggle keyboard-accessible while remaining open by default. This ensures the TOC remains usable in AMP caches and any environment where scripts are disallowed.【F:includes/frontend/class-frontend.php†L43-L120】【F:assets/css/frontend.css†L1-L160】
+
+> **Manual regression:** Install the official AMP plugin in *Transitional* mode, load any single post both in canonical and `?amp` views, and verify that the AMP endpoint shows the expanded TOC without enqueued JavaScript while the canonical page retains the interactive floating accordion.
+
 ## SEO Compatibility
 
 - **Rank Math** – the plugin registers itself among supported TOCs, preventing the “No TOC plugin installed” warning.

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -26,9 +26,38 @@
     transform: translate3d(var(--wwt-toc-translate-x), var(--wwt-toc-translate-y), 0);
 }
 
+.wwt-toc-container[data-render-mode="static"] {
+    position: relative;
+    left: auto;
+    right: auto;
+    top: auto;
+    bottom: auto;
+    width: min(640px, 100%);
+    max-width: 100%;
+    margin: 2rem auto;
+    transform: none;
+    box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
+    overflow: visible;
+}
+
+.wwt-toc-container[data-render-mode="static"]::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 55%);
+    pointer-events: none;
+    z-index: 0;
+}
+
 .wwt-toc-container:hover {
     transform: translate3d(var(--wwt-toc-translate-x), calc(var(--wwt-toc-translate-y) - 2px), 0);
     box-shadow: 0 32px 60px rgba(15, 23, 42, 0.45);
+}
+
+.wwt-toc-container[data-render-mode="static"]:hover {
+    transform: none;
+    box-shadow: 0 24px 45px rgba(15, 23, 42, 0.18);
 }
 
 .wwt-toc-container[data-align-x="left"] {
@@ -137,6 +166,14 @@
     transform: translate(-50%, -50%) rotate(180deg);
 }
 
+.wwt-toc-accordion[open] .wwt-toc-icon::after {
+    transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.wwt-toc-accordion[open] .wwt-toc-icon::before {
+    transform: translate(-50%, -50%) rotate(180deg);
+}
+
 .wwt-toc-content {
     max-height: 60vh;
     overflow-y: auto;
@@ -157,6 +194,54 @@
 
 .wwt-toc-nav {
     font-size: 0.95rem;
+}
+
+.wwt-toc-container[data-render-mode="static"] .wwt-toc-accordion {
+    position: relative;
+    z-index: 1;
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    background-color: var(--wwt-toc-bg) !important;
+    box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+}
+
+.wwt-toc-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 1rem 1.35rem;
+    list-style: none;
+    background: var(--wwt-toc-title-bg) !important;
+    color: var(--wwt-toc-title-color) !important;
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+.wwt-toc-summary::-webkit-details-marker {
+    display: none;
+}
+
+.wwt-toc-summary:focus,
+.wwt-toc-summary:focus-visible {
+    outline: 2px solid var(--wwt-toc-link);
+    outline-offset: 2px;
+}
+
+.wwt-toc-summary-text {
+    flex: 1;
+    padding-right: 2.75rem;
+}
+
+.wwt-toc-container[data-render-mode="static"] .wwt-toc-content {
+    max-height: none;
+    overflow: visible;
+    padding: 1.35rem 1.5rem 1.85rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(148, 163, 184, 0.08));
 }
 
 .wwt-toc-list {


### PR DESCRIPTION
## Summary
- detect AMP requests and avoid enqueuing the interactive script when the page is rendered in AMP mode
- render a `<details>`-based TOC variant for AMP/no-JS contexts while keeping the existing interactive markup for canonical views
- refresh frontend styles to present the static layout cleanly and document the new AMP compatibility workflow in the README

## Testing
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dfcae2c9c88333bc6301320a3870a4