### PR TITLE
Prevent AMP TOC markup from outputting inline style tags

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -26,6 +26,16 @@
     transform: translate3d(var(--wwt-toc-translate-x), var(--wwt-toc-translate-y), 0);
 }
 
+.wwt-has-custom-title-colors .wwt-toc-header,
+.wwt-has-custom-title-colors .wwt-toc-summary {
+    background: var(--wwt-toc-title-bg) !important;
+    color: var(--wwt-toc-title-color) !important;
+}
+
+.wwt-has-custom-title-colors .wwt-toc-toggle {
+    color: var(--wwt-toc-title-color) !important;
+}
+
 .wwt-toc-container[data-render-mode="static"] {
     position: relative;
     left: auto;

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -448,9 +448,15 @@ class Frontend {
             $vertical = 'bottom';
         }
 
+        $classes = array( 'wwt-toc-container' );
+
+        if ( ! empty( $preferences['has_custom_title_colors'] ) ) {
+            $classes[] = 'wwt-has-custom-title-colors';
+        }
+
         $attributes = array(
             'id'               => $id,
-            'class'            => 'wwt-toc-container',
+            'class'            => implode( ' ', $classes ),
             'data-align-x'     => $horizontal,
             'data-align-y'     => $vertical,
             'data-render-mode' => $is_interactive ? 'interactive' : 'static',
@@ -537,7 +543,7 @@ class Frontend {
      * @param string              $element_id  Control element ID.
      */
     protected function build_custom_title_style( array $preferences, string $element_id ): string {
-        if ( empty( $preferences['has_custom_title_colors'] ) ) {
+        if ( $this->is_amp_request() || empty( $preferences['has_custom_title_colors'] ) ) {
             return '';
         }
 


### PR DESCRIPTION
## Summary
- avoid adding inline title style blocks when the frontend renders in AMP mode
- add a container class to preserve custom title colors through regular CSS rules instead of inline styles

## Testing
- php -r 'define("ABSPATH", true); function esc_attr( $text ) { return $text; } function esc_html( $text ) { return $text; } function esc_html__( $text, $domain = null ) { return $text; } function __( $text, $domain = null ) { return $text; } function absint( $value ) { return abs( (int) $value ); } require "includes/class-settings.php"; require "includes/frontend/class-frontend.php"; class Dummy_Settings extends Working_With_TOC\Settings { public function get_horizontal_alignment_choices(): array { return array( "left", "center", "right" ); } public function get_vertical_alignment_choices(): array { return array( "top", "bottom" ); } } class Dummy_Frontend extends Working_With_TOC\Frontend\Frontend { protected function is_amp_request(): bool { return true; } public function output_static_markup(): string { $preferences = array( "title" => "My TOC", "has_custom_title_colors" => true, "title_background_color" => "#000000", "title_color" => "#ffffff", "background_color" => "#ffffff", "text_color" => "#111111", "link_color" => "#222222", "horizontal_alignment" => "left", "vertical_alignment" => "top", ); $headings = array( array( "title" => "Intro", "id" => "intro", "level" => 2 ), ); return $this->build_toc_markup( $headings, $preferences, 123, true ); } } $frontend = new Dummy_Frontend( new Dummy_Settings() ); $output = $frontend->output_static_markup(); if ( false !== strpos( $output, "<style" ) ) { fwrite( STDERR, "Found style tag in markup\n" ); } echo $output;'

------
https://chatgpt.com/codex/tasks/task_e_68dfcf91f3448333ba87a9f4492b95db