### PR TITLE
Add AMP-safe styling pipeline for TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ When FAQ mode is enabled for specific headings, the parser annotates the matched
 
 ### AMP compatibility
 
-The frontend now detects AMP requests (using `is_amp_endpoint()` or `amp_is_request()` when available) and renders an accessible, always-on TOC without relying on JavaScript listeners. In AMP mode the plugin skips loading `assets/js/frontend.js` and swaps the floating container for a `<details>`-based layout that keeps the toggle keyboard-accessible while remaining open by default. This ensures the TOC remains usable in AMP caches and any environment where scripts are disallowed.【F:includes/frontend/class-frontend.php†L43-L120】【F:assets/css/frontend.css†L1-L160】
+The frontend now detects AMP requests (using `is_amp_endpoint()` or `amp_is_request()` when available) and renders an accessible, always-on TOC without relying on JavaScript listeners. In AMP mode the plugin skips loading `assets/js/frontend.js`, swaps the floating container for a `<details>`-based layout that keeps the toggle keyboard-accessible while remaining open by default, and assigns a deterministic `wwt-color-scheme-{hash}` class so colors are sourced from the enqueued stylesheet instead of inline attributes. This ensures AMP markup remains valid while preserving the configured palette through CSS custom properties defined in `assets/css/frontend.css`.【F:includes/frontend/class-frontend.php†L43-L120】【F:includes/frontend/class-frontend.php†L245-L366】【F:assets/css/frontend.css†L1-L120】
 
-> **Manual regression:** Install the official AMP plugin in *Transitional* mode, load any single post both in canonical and `?amp` views, and verify that the AMP endpoint shows the expanded TOC without enqueued JavaScript while the canonical page retains the interactive floating accordion.
+> **Manual regression:** Install the official AMP plugin in *Transitional* mode, load any single post both in canonical and `?amp` views, and verify that the AMP endpoint shows the expanded TOC without enqueued JavaScript or inline `style` attributes in the TOC markup while the canonical page retains the interactive floating accordion and inline custom properties for JS-driven behavior.【F:includes/frontend/class-frontend.php†L57-L109】【F:includes/frontend/class-frontend.php†L245-L366】
 
 ## SEO Compatibility
 

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -26,6 +26,23 @@
     transform: translate3d(var(--wwt-toc-translate-x), var(--wwt-toc-translate-y), 0);
 }
 
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] {
+    background-color: var(--wwt-toc-bg) !important;
+    color: var(--wwt-toc-text) !important;
+}
+
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] .wwt-toc-header,
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] .wwt-toc-summary {
+    background: var(--wwt-toc-title-bg) !important;
+    color: var(--wwt-toc-title-color) !important;
+}
+
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] .wwt-toc-list a:hover,
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] .wwt-toc-list a:focus,
+.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] .wwt-toc-list a.is-active {
+    color: var(--wwt-toc-link);
+}
+
 .wwt-has-custom-title-colors .wwt-toc-header,
 .wwt-has-custom-title-colors .wwt-toc-summary {
     background: var(--wwt-toc-title-bg) !important;


### PR DESCRIPTION
## Summary
- stop emitting inline style attributes for AMP TOC containers while keeping JS behavior for canonical pages
- generate deterministic AMP color-scheme classes, enqueue their CSS via `wp_add_inline_style()`, and update the static markup to apply them
- document the AMP validation workflow and extend the stylesheet so static renderings inherit the configured palette

## Testing
- php -l includes/frontend/class-frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd321dc648333ac5f7ad58411ec0a