### PR TITLE
Rename admin menu entry to www TOC

### DIFF
--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -88,7 +88,7 @@ class Admin_Page {
     public function register_menu(): void {
         add_menu_page(
             __( 'Working with TOC', 'working-with-toc' ),
-            __( 'Working with TOC', 'working-with-toc' ),
+            __( 'www TOC', 'working-with-toc' ),
             $this->capability,
             'working-with-toc',
             array( $this, 'render_page' ),


### PR DESCRIPTION
## Summary
- rename the plugin's top-level admin menu label to "www TOC" to match the requested naming

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e006e50fd8833395dd36bdc965d606