### PR TITLE
Remove AMP CSS custom properties for validator compliance

### DIFF
--- a/assets/css/frontend-amp.css
+++ b/assets/css/frontend-amp.css
@@ -1,14 +1,9 @@
 .wwt-toc-container {
-    --wwt-toc-bg: #ffffff;
-    --wwt-toc-title-bg: #1f2937;
-    --wwt-toc-title-color: #ffffff;
-    --wwt-toc-text: #111827;
-    --wwt-toc-link: #2563eb;
     width: 100%;
     max-width: 640px;
     margin: 1.5rem auto;
-    background-color: var(--wwt-toc-bg);
-    color: var(--wwt-toc-text);
+    background-color: #ffffff;
+    color: #111827;
     border-radius: 18px;
     border: 1px solid rgba(148, 163, 184, 0.25);
     box-shadow: 0 18px 38px rgba(15, 23, 42, 0.18);
@@ -33,17 +28,6 @@
     margin-bottom: 0;
 }
 
-.wwt-toc-container[data-render-mode="static"][class*="wwt-color-scheme-"] {
-    background-color: var(--wwt-toc-bg);
-    color: var(--wwt-toc-text);
-}
-
-.wwt-has-custom-title-colors .wwt-toc-summary,
-.wwt-has-custom-title-colors .wwt-toc-summary-text {
-    background: var(--wwt-toc-title-bg);
-    color: var(--wwt-toc-title-color);
-}
-
 .wwt-toc-accordion {
     margin: 0;
 }
@@ -53,8 +37,8 @@
     align-items: center;
     justify-content: space-between;
     padding: 1rem 1.25rem;
-    background: var(--wwt-toc-title-bg);
-    color: var(--wwt-toc-title-color);
+    background: #1f2937;
+    color: #ffffff;
     border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     cursor: pointer;
     list-style: none;
@@ -69,6 +53,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.02em;
+    color: inherit;
 }
 
 .wwt-toc-icon {
@@ -114,7 +99,7 @@
 }
 
 .wwt-toc-list a {
-    color: var(--wwt-toc-link);
+    color: #2563eb;
     text-decoration: none;
 }
 

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -665,36 +665,56 @@ class Frontend {
             return '';
         }
 
-        $variable_map = array(
-            'background_color'       => '--wwt-toc-bg',
-            'text_color'             => '--wwt-toc-text',
-            'link_color'             => '--wwt-toc-link',
-            'title_background_color' => '--wwt-toc-title-bg',
-            'title_color'            => '--wwt-toc-title-color',
-        );
-
         $rules = array();
 
         foreach ( $this->amp_color_schemes as $class => $colors ) {
-            $declarations = array();
+            $sanitized_class = sanitize_html_class( $class );
 
-            foreach ( $variable_map as $preference_key => $variable_name ) {
-                if ( empty( $colors[ $preference_key ] ) ) {
-                    continue;
-                }
-
-                $declarations[] = sprintf( '%1$s:%2$s;', $variable_name, $colors[ $preference_key ] );
-            }
-
-            if ( empty( $declarations ) ) {
+            if ( '' === $sanitized_class ) {
                 continue;
             }
 
-            $rules[] = sprintf(
-                '.wwt-toc-container.%1$s{%2$s}',
-                sanitize_html_class( $class ),
-                implode( '', $declarations )
-            );
+            $container_declarations = array();
+            if ( ! empty( $colors['background_color'] ) ) {
+                $container_declarations[] = sprintf( 'background-color:%s;', $colors['background_color'] );
+            }
+
+            if ( ! empty( $colors['text_color'] ) ) {
+                $container_declarations[] = sprintf( 'color:%s;', $colors['text_color'] );
+            }
+
+            if ( ! empty( $container_declarations ) ) {
+                $rules[] = sprintf(
+                    '.wwt-toc-container.%1$s{%2$s}',
+                    $sanitized_class,
+                    implode( '', $container_declarations )
+                );
+            }
+
+            $title_declarations = array();
+            if ( ! empty( $colors['title_background_color'] ) ) {
+                $title_declarations[] = sprintf( 'background:%s;', $colors['title_background_color'] );
+            }
+
+            if ( ! empty( $colors['title_color'] ) ) {
+                $title_declarations[] = sprintf( 'color:%s;', $colors['title_color'] );
+            }
+
+            if ( ! empty( $title_declarations ) ) {
+                $rules[] = sprintf(
+                    '.wwt-toc-container.%1$s .wwt-toc-summary,.wwt-toc-container.%1$s .wwt-toc-summary-text{%2$s}',
+                    $sanitized_class,
+                    implode( '', $title_declarations )
+                );
+            }
+
+            if ( ! empty( $colors['link_color'] ) ) {
+                $rules[] = sprintf(
+                    '.wwt-toc-container.%1$s .wwt-toc-list a{color:%2$s;}',
+                    $sanitized_class,
+                    $colors['link_color']
+                );
+            }
         }
 
         return implode( '', $rules );


### PR DESCRIPTION
## Summary
- replace the AMP stylesheet's CSS custom properties with concrete color declarations so it no longer violates AMP's CSS parser
- update the AMP color scheme builder to emit explicit background, text, and link rules that mirror the removed custom properties

## Testing
- node node_modules/amphtml-validator/cli.js --validator_js validator_wasm.js /tmp/test-amp.html

------
https://chatgpt.com/codex/tasks/task_e_68e44602c7e08333900b23590c695980