### PR TITLE
Enhance WooCommerce product metadata generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All settings are stored using core WordPress options and post meta, avoiding cus
 - Automatic anchor ID generation for `<h2>-<h6>` headings with links kept in sync across the TOC.
 - Custom admin page with toggles to enable the TOC and structured data for posts, pages, and WooCommerce products.
 - JSON-LD `ItemList` output compatible with Rank Math and Yoast SEO schema graphs.
+- Comprehensive WooCommerce product metadata including GTIN/MPN identifiers, reviews, shipping details, and Open Graph fallbacks.
 - Conditional logging keyed off the `WP_DEBUG` flag so production sites stay clean.
 
 ## Screenshots

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -24,6 +24,7 @@ All settings are stored using core WordPress options and post meta, avoiding cus
 - Automatic anchor ID generation for `<h2>-<h6>` headings with links kept in sync across the TOC.
 - Custom admin page with toggles to enable the TOC and structured data for posts, pages, and WooCommerce products.
 - JSON-LD `ItemList` output compatible with Rank Math and Yoast SEO schema graphs.
+- Comprehensive WooCommerce product metadata including GTIN/MPN identifiers, reviews, shipping details, and Open Graph fallbacks.
 - Conditional logging keyed off the `WP_DEBUG` flag so production sites stay clean.
 
 ## Screenshots

--- a/README_it_IT.md
+++ b/README_it_IT.md
@@ -24,6 +24,7 @@ La configurazione viene salvata attraverso le normali opzioni e i meta di WordPr
 - Generazione automatica degli anchor ID sui titoli `<h2>-<h6>` e sincronizzazione con gli URL della TOC.
 - Pannello di amministrazione personalizzato con interruttori per attivare TOC e dati strutturati per articoli, pagine e prodotti WooCommerce.
 - Output JSON-LD compatibile basato su `ItemList` per articoli, pagine e prodotti, integrato nel grafo schema di Yoast SEO e riconosciuto da Rank Math.
+- Metadati completi per i prodotti WooCommerce con identificativi GTIN/MPN, recensioni, costi di spedizione e fallback Open Graph.
 - Logging condizionato sul flag `WP_DEBUG` per agevolare il debug senza inquinare l'ambiente di produzione.
 
 ## Screenshot

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -377,6 +377,23 @@
     width: 100%;
 }
 
+.wwt-toc-structured-data__field--checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.wwt-toc-structured-data__field--checkbox label {
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.wwt-toc-structured-data__field--checkbox input {
+    width: auto;
+}
+
 .wwt-toc-style__color {
     display: flex;
     flex-direction: column;

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -190,6 +190,11 @@ class Admin_Page {
                     'top'    => __( 'Top', 'working-with-toc' ),
                     'bottom' => __( 'Bottom', 'working-with-toc' ),
                 );
+                $condition_options = array(
+                    'https://schema.org/NewCondition'         => __( 'New', 'working-with-toc' ),
+                    'https://schema.org/UsedCondition'        => __( 'Used', 'working-with-toc' ),
+                    'https://schema.org/RefurbishedCondition' => __( 'Refurbished', 'working-with-toc' ),
+                );
                 ?>
                 <div class="wwt-toc-card-grid">
                     <?php foreach ( $cards as $prefix => $card ) :
@@ -205,6 +210,14 @@ class Admin_Page {
                         $description_field_id   = sprintf( 'wwt_toc_%s_schema_fallback_description', $prefix );
                         $image_field_name       = sprintf( '%s[%s_schema_fallback_image]', Settings::OPTION_NAME, $prefix );
                         $image_field_id         = sprintf( 'wwt_toc_%s_schema_fallback_image', $prefix );
+                        $brand_attribute_field_name = sprintf( '%s[products_schema_brand_attribute]', Settings::OPTION_NAME );
+                        $brand_attribute_field_id   = 'wwt_toc_products_schema_brand_attribute';
+                        $brand_fallback_field_name  = sprintf( '%s[products_schema_fallback_brand]', Settings::OPTION_NAME );
+                        $brand_fallback_field_id    = 'wwt_toc_products_schema_fallback_brand';
+                        $sku_fallback_field_name    = sprintf( '%s[products_schema_allow_id_as_sku]', Settings::OPTION_NAME );
+                        $sku_fallback_field_id      = 'wwt_toc_products_schema_allow_id_as_sku';
+                        $condition_field_name       = sprintf( '%s[products_schema_condition]', Settings::OPTION_NAME );
+                        $condition_field_id         = 'wwt_toc_products_schema_condition';
                         ?>
                         <div class="wwt-toc-card">
                             <h2><?php echo esc_html( $card['heading'] ); ?></h2>
@@ -279,6 +292,32 @@ class Admin_Page {
                                     <label for="<?php echo esc_attr( $image_field_id ); ?>"><?php esc_html_e( 'Fallback image URL', 'working-with-toc' ); ?></label>
                                     <input type="url" id="<?php echo esc_attr( $image_field_id ); ?>" name="<?php echo esc_attr( $image_field_name ); ?>" value="<?php echo esc_attr( $settings[ $prefix . '_schema_fallback_image' ] ); ?>" class="widefat" />
                                 </div>
+                                <?php if ( 'products' === $prefix ) : ?>
+                                    <div class="wwt-toc-structured-data__field">
+                                        <label for="<?php echo esc_attr( $brand_attribute_field_id ); ?>"><?php esc_html_e( 'Brand attribute slug', 'working-with-toc' ); ?></label>
+                                        <input type="text" id="<?php echo esc_attr( $brand_attribute_field_id ); ?>" name="<?php echo esc_attr( $brand_attribute_field_name ); ?>" value="<?php echo esc_attr( $settings['products_schema_brand_attribute'] ); ?>" class="widefat" />
+                                        <p class="description"><?php esc_html_e( 'Provide the product attribute slug that stores the brand (for example "pa_brand").', 'working-with-toc' ); ?></p>
+                                    </div>
+                                    <div class="wwt-toc-structured-data__field">
+                                        <label for="<?php echo esc_attr( $brand_fallback_field_id ); ?>"><?php esc_html_e( 'Fallback brand name', 'working-with-toc' ); ?></label>
+                                        <input type="text" id="<?php echo esc_attr( $brand_fallback_field_id ); ?>" name="<?php echo esc_attr( $brand_fallback_field_name ); ?>" value="<?php echo esc_attr( $settings['products_schema_fallback_brand'] ); ?>" class="widefat" />
+                                        <p class="description"><?php esc_html_e( 'Used when the attribute above is empty for a product.', 'working-with-toc' ); ?></p>
+                                    </div>
+                                    <div class="wwt-toc-structured-data__field wwt-toc-structured-data__field--checkbox">
+                                        <label for="<?php echo esc_attr( $sku_fallback_field_id ); ?>">
+                                            <input type="checkbox" id="<?php echo esc_attr( $sku_fallback_field_id ); ?>" name="<?php echo esc_attr( $sku_fallback_field_name ); ?>" value="1" <?php checked( ! empty( $settings['products_schema_allow_id_as_sku'] ) ); ?> />
+                                            <?php esc_html_e( 'Use the product ID when the SKU is missing', 'working-with-toc' ); ?>
+                                        </label>
+                                    </div>
+                                    <div class="wwt-toc-structured-data__field">
+                                        <label for="<?php echo esc_attr( $condition_field_id ); ?>"><?php esc_html_e( 'Default product condition', 'working-with-toc' ); ?></label>
+                                        <select id="<?php echo esc_attr( $condition_field_id ); ?>" name="<?php echo esc_attr( $condition_field_name ); ?>">
+                                            <?php foreach ( $condition_options as $value => $label ) : ?>
+                                                <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $settings['products_schema_condition'], $value ); ?>><?php echo esc_html( $label ); ?></option>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                <?php endif; ?>
                             </div>
                         </div>
                     <?php endforeach; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -23,6 +23,7 @@ It stores its configuration using standard WordPress options and post meta, with
 * Automatic heading anchor generation (`<h2>`–`<h6>`) that keeps TOC links synchronized with on-page headings.
 * Admin page with toggles to enable the TOC and Schema.org `ItemList` data by post type.
 * JSON-LD output compatible with Rank Math and Yoast SEO schema graphs, avoiding duplicate markup.
+* Comprehensive WooCommerce product metadata covering GTIN/MPN identifiers, reviews, shipping costs, and Open Graph fallbacks.
 * Conditional logging that respects the `WP_DEBUG` flag for safe troubleshooting in development environments.
 
 = Admin Permissions =


### PR DESCRIPTION
## Summary
- enrich WooCommerce product schema with brand fallbacks, GTIN/MPN identifiers, reviews, shipping details, offers, and variation nodes
- expose reusable product metadata helpers in settings and open graph manager and extend Open Graph tags with price, availability, condition, brand, and image dimensions
- surface new product metadata controls in the admin UI, adjust styling, and document the expanded coverage in the readme files

## Testing
- php -l includes/structured-data/class-structured-data-manager.php
- php -l includes/frontend/class-open-graph-manager.php
- php -l includes/admin/class-admin-page.php
- php -l includes/class-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68e6b7dd18808333b947ba9c50440f1c