### PR TITLE
Add product identifier support to structured data and OG tags

### DIFF
--- a/includes/structured-data/class-structured-data-manager.php
+++ b/includes/structured-data/class-structured-data-manager.php
@@ -2389,6 +2389,37 @@ class Structured_Data_Manager {
     }
 
     /**
+     * Retrieve a condensed set of product identifiers for reuse outside structured data.
+     *
+     * @param \WC_Product $product Product instance.
+     *
+     * @return array{
+     *     sku:string,
+     *     mpn:string,
+     *     brand:string,
+     *     gtin:array<string,string>
+     * }
+     */
+    public function get_product_identifier_snapshot( \WC_Product $product ): array {
+        $schema_settings = $this->settings->get_product_structured_data_settings();
+
+        $sku = $this->resolve_product_sku( $product, $schema_settings );
+        $mpn = $this->resolve_product_mpn( $product, $schema_settings, $sku );
+
+        $brand_data = $this->resolve_product_brand_data( $product, $schema_settings );
+        $brand_name = isset( $brand_data['name'] ) ? (string) $brand_data['name'] : '';
+
+        $gtins = $this->resolve_product_gtin_values( $product );
+
+        return array(
+            'sku'   => $sku,
+            'mpn'   => $mpn,
+            'brand' => $brand_name,
+            'gtin'  => is_array( $gtins ) ? $gtins : array(),
+        );
+    }
+
+    /**
      * Return the resolved product brand label for reuse outside structured data.
      *
      * @param \WC_Product $product Product instance.


### PR DESCRIPTION
## Summary
- expose a reusable product identifier snapshot so other systems can consistently access SKU/MPN/GTIN data
- enrich the Open Graph fallback generator with SKU, retailer item id, MPN, GTIN, UPC/EAN, and item group handling plus condition fallback logic
- normalise numeric product identifiers before output so meta tags always contain clean values

## Testing
- php -l includes/frontend/class-open-graph-manager.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68e6c1a397288333ae509c33a33315a6