### PR TITLE
Support WooCommerce short descriptions when building TOCs

### DIFF
--- a/includes/class-heading-parser.php
+++ b/includes/class-heading-parser.php
@@ -24,7 +24,11 @@ class Heading_Parser {
      * Parse content and return headings plus updated content.
      *
      * @param string $content HTML content.
-     * @param array  $options Parsing options.
+     * @param array  $options Parsing options. Supported options:
+     *                        - faq_ids (array<string>): Headings marked as FAQ questions.
+     *                        - mark_faq (bool): Whether to decorate FAQ headings.
+     *                        - mark_faq_answers (bool): Whether to decorate FAQ answers.
+     *                        - reserved_ids (array<string>): IDs that must not be reused.
      *
      * @return array{headings:array<int,array{title:string,id:string,level:int,faq_excerpt?:string,faq_answer?:string}>,content:string}
      */
@@ -66,6 +70,24 @@ class Heading_Parser {
         $nodes    = $xpath->query( '//h2 | //h3 | //h4 | //h5 | //h6' );
         $headings = array();
         $used_ids = array();
+
+        if ( isset( $options['reserved_ids'] ) && is_array( $options['reserved_ids'] ) ) {
+            foreach ( $options['reserved_ids'] as $reserved_id ) {
+                if ( ! is_string( $reserved_id ) ) {
+                    continue;
+                }
+
+                $reserved_id = trim( $reserved_id );
+
+                if ( '' === $reserved_id ) {
+                    continue;
+                }
+
+                if ( ! in_array( $reserved_id, $used_ids, true ) ) {
+                    $used_ids[] = $reserved_id;
+                }
+            }
+        }
 
         if ( $nodes ) {
             $length = $nodes->length;

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -83,6 +83,13 @@ class Plugin {
         add_action( 'admin_enqueue_scripts', array( $this->meta_box, 'enqueue_assets' ) );
         add_action( 'wp_enqueue_scripts', array( $this->frontend, 'enqueue_assets' ) );
         add_filter( 'the_content', array( $this->frontend, 'inject_toc' ), 15 );
+        if ( post_type_exists( 'product' ) ) {
+            add_filter(
+                'woocommerce_short_description',
+                array( $this->frontend, 'filter_woocommerce_short_description' ),
+                Frontend::WOOCOMMERCE_SHORT_DESCRIPTION_PRIORITY
+            );
+        }
         add_action( 'wp_head', array( $this->open_graph, 'start_buffer' ), 0 );
         add_action( 'wp_head', array( $this->structured_data, 'output_structured_data' ) );
         add_action( 'wp_head', array( $this->open_graph, 'output_open_graph_tags' ), 9999 );


### PR DESCRIPTION
## Summary
- parse WooCommerce short descriptions so heading anchors are added and cached for TOC generation
- merge headings from product short and long descriptions before rendering the TOC markup
- extend the heading parser to honour reserved IDs, preventing duplicate anchors across segments

## Testing
- `php -l includes/frontend/class-frontend.php`
- `php -l includes/class-heading-parser.php`
- `php -l includes/class-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68e6d2b622348333abdbeedbec0d1026