### PR TITLE
Improve mobile TOC behaviour and add organization address fallback

### DIFF
--- a/assets/js/frontend-mobile.js
+++ b/assets/js/frontend-mobile.js
@@ -1,0 +1,153 @@
+;(function () {
+    'use strict';
+
+    function cssEscape(value) {
+        if (window.CSS && typeof window.CSS.escape === 'function') {
+            return window.CSS.escape(value);
+        }
+        return value.replace(/([\s#:?&.,])/g, '\\$1');
+    }
+
+    var initialized = false;
+
+    function applyContainerColors(container) {
+        var map = {
+            bg: '--wwt-toc-bg',
+            text: '--wwt-toc-text',
+            link: '--wwt-toc-link',
+            titleBg: '--wwt-toc-title-bg',
+            titleColor: '--wwt-toc-title-color'
+        };
+
+        Object.keys(map).forEach(function (dataKey) {
+            var cssVar = map[dataKey];
+            var value = container.dataset[dataKey];
+            if (value) {
+                container.style.setProperty(cssVar, value);
+            }
+        });
+    }
+
+    function togglePanel(container, expanded) {
+        var button = container.querySelector('.wwt-toc-toggle');
+        var panel = container.querySelector('.wwt-toc-content');
+
+        container.dataset.expanded = String(expanded);
+        if (button) {
+            button.setAttribute('aria-expanded', String(expanded));
+        }
+        if (panel) {
+            if (expanded) {
+                panel.removeAttribute('hidden');
+            } else {
+                panel.setAttribute('hidden', '');
+            }
+        }
+    }
+
+    function createHighlightBinder() {
+        if (!('IntersectionObserver' in window)) {
+            return function () {};
+        }
+
+        var bound = false;
+
+        return function bindHighlight() {
+            if (bound) {
+                return;
+            }
+            bound = true;
+
+            var observer = new IntersectionObserver(function (entries) {
+                entries.forEach(function (entry) {
+                    var id = entry.target.getAttribute('id');
+                    if (!id) {
+                        return;
+                    }
+
+                    var link = document.querySelector('.wwt-toc-list a[href="#' + cssEscape(id) + '"]');
+                    if (!link) {
+                        return;
+                    }
+
+                    if (entry.isIntersecting) {
+                        var activeLinks = document.querySelectorAll('.wwt-toc-list a.is-active');
+                        Array.prototype.forEach.call(activeLinks, function (active) {
+                            active.classList.remove('is-active');
+                        });
+                        link.classList.add('is-active');
+                    }
+                });
+            }, {
+                rootMargin: '-50% 0px -40% 0px',
+                threshold: 0.1
+            });
+
+            var targets = document.querySelectorAll('h2[id], h3[id], h4[id], h5[id], h6[id]');
+            Array.prototype.forEach.call(targets, function (target) {
+                observer.observe(target);
+            });
+        };
+    }
+
+    function init() {
+        if (initialized) {
+            return;
+        }
+
+        var containers = document.querySelectorAll('[data-wwt-toc]');
+        if (!containers.length) {
+            return;
+        }
+
+        initialized = true;
+
+        var bindHighlight = createHighlightBinder();
+
+        Array.prototype.forEach.call(containers, function (container) {
+            applyContainerColors(container);
+
+            var button = container.querySelector('.wwt-toc-toggle');
+            var panel = container.querySelector('.wwt-toc-content');
+
+            if (!button || !panel) {
+                return;
+            }
+
+            var expanded = container.dataset.expanded === 'true';
+            togglePanel(container, expanded);
+
+            var ensureHighlight = function () {
+                if (container.dataset.expanded === 'true') {
+                    if ('requestIdleCallback' in window) {
+                        window.requestIdleCallback(bindHighlight, { timeout: 1000 });
+                    } else {
+                        setTimeout(bindHighlight, 0);
+                    }
+                }
+            };
+
+            if (expanded) {
+                ensureHighlight();
+            }
+
+            button.addEventListener('click', function () {
+                var isExpanded = container.dataset.expanded === 'true';
+                togglePanel(container, !isExpanded);
+                ensureHighlight();
+            });
+
+            button.addEventListener('keydown', function (event) {
+                if (event.key === 'Escape') {
+                    togglePanel(container, false);
+                }
+            });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -339,6 +339,26 @@ class Admin_Page {
                             <label for="wwt_toc_organization_logo"><?php esc_html_e( 'Logo URL', 'working-with-toc' ); ?></label>
                             <input type="url" id="wwt_toc_organization_logo" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_logo]" value="<?php echo esc_attr( $settings['organization_logo'] ); ?>" class="regular-text" />
                         </div>
+                        <div class="wwt-toc-organization__field">
+                            <label for="wwt_toc_organization_address_street"><?php esc_html_e( 'Street address', 'working-with-toc' ); ?></label>
+                            <input type="text" id="wwt_toc_organization_address_street" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_address_street]" value="<?php echo esc_attr( $settings['organization_address_street'] ); ?>" class="regular-text" />
+                        </div>
+                        <div class="wwt-toc-organization__field">
+                            <label for="wwt_toc_organization_address_locality"><?php esc_html_e( 'City / locality', 'working-with-toc' ); ?></label>
+                            <input type="text" id="wwt_toc_organization_address_locality" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_address_locality]" value="<?php echo esc_attr( $settings['organization_address_locality'] ); ?>" class="regular-text" />
+                        </div>
+                        <div class="wwt-toc-organization__field">
+                            <label for="wwt_toc_organization_address_region"><?php esc_html_e( 'Region / state', 'working-with-toc' ); ?></label>
+                            <input type="text" id="wwt_toc_organization_address_region" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_address_region]" value="<?php echo esc_attr( $settings['organization_address_region'] ); ?>" class="regular-text" />
+                        </div>
+                        <div class="wwt-toc-organization__field">
+                            <label for="wwt_toc_organization_address_postal_code"><?php esc_html_e( 'Postal code', 'working-with-toc' ); ?></label>
+                            <input type="text" id="wwt_toc_organization_address_postal_code" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_address_postal_code]" value="<?php echo esc_attr( $settings['organization_address_postal_code'] ); ?>" class="regular-text" />
+                        </div>
+                        <div class="wwt-toc-organization__field">
+                            <label for="wwt_toc_organization_address_country"><?php esc_html_e( 'Country', 'working-with-toc' ); ?></label>
+                            <input type="text" id="wwt_toc_organization_address_country" name="<?php echo esc_attr( Settings::OPTION_NAME ); ?>[organization_address_country]" value="<?php echo esc_attr( $settings['organization_address_country'] ); ?>" class="regular-text" />
+                        </div>
                     </div>
                 </section>
 

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -69,6 +69,26 @@ class Settings {
                 'type'    => 'url',
                 'default' => $this->get_default_logo_url(),
             ),
+            'organization_address_street' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
+            'organization_address_locality' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
+            'organization_address_region' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
+            'organization_address_postal_code' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
+            'organization_address_country' => array(
+                'type'    => 'string',
+                'default' => '',
+            ),
         );
 
         $style_defaults = array(
@@ -498,9 +518,16 @@ class Settings {
         $settings = $this->get_settings();
 
         return array(
-            'name' => $settings['organization_name'] ?? get_bloginfo( 'name' ),
-            'url'  => $settings['organization_url'] ?? home_url( '/' ),
-            'logo' => $settings['organization_logo'] ?? '',
+            'name'    => $settings['organization_name'] ?? get_bloginfo( 'name' ),
+            'url'     => $settings['organization_url'] ?? home_url( '/' ),
+            'logo'    => $settings['organization_logo'] ?? '',
+            'address' => array(
+                'street'      => $settings['organization_address_street'] ?? '',
+                'locality'    => $settings['organization_address_locality'] ?? '',
+                'region'      => $settings['organization_address_region'] ?? '',
+                'postal_code' => $settings['organization_address_postal_code'] ?? '',
+                'country'     => $settings['organization_address_country'] ?? '',
+            ),
         );
     }
 

--- a/includes/frontend/class-frontend.php
+++ b/includes/frontend/class-frontend.php
@@ -17,6 +17,7 @@ use Working_With_TOC\Heading_Parser;
 use Working_With_TOC\Settings;
 use function Working_With_TOC\is_domdocument_missing;
 use function sanitize_html_class;
+use function wp_is_mobile;
 use function wp_json_encode;
 
 /**
@@ -119,9 +120,17 @@ class Frontend {
             return;
         }
 
+        $script_handle = 'wwt-toc-frontend';
+        $script_path   = 'assets/js/frontend.js';
+
+        if ( wp_is_mobile() ) {
+            $script_handle = 'wwt-toc-frontend-mobile';
+            $script_path   = 'assets/js/frontend-mobile.js';
+        }
+
         wp_enqueue_script(
-            'wwt-toc-frontend',
-            WWT_TOC_PLUGIN_URL . 'assets/js/frontend.js',
+            $script_handle,
+            WWT_TOC_PLUGIN_URL . $script_path,
             array(),
             WWTOC_VERSION,
             true


### PR DESCRIPTION
## Summary
- detect mobile requests and load a lighter TOC script while keeping the desktop assets
- introduce a mobile-focused TOC script that delays intersection observers until the panel is opened
- add organization address fallback settings and inject the resulting PostalAddress into structured data outputs and SEO integrations

## Testing
- php -l includes/frontend/class-frontend.php
- php -l includes/class-settings.php
- php -l includes/admin/class-admin-page.php
- php -l includes/structured-data/class-structured-data-manager.php

------
https://chatgpt.com/codex/tasks/task_e_68e8293659f48333956bb2cc12af1d9e